### PR TITLE
[Tier-1] docs: PR approval tier governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Tier-1 surfaces (docs/GOVERNANCE.md): changes here require the repo owner's review.
+# Enforced via branch ruleset "require review from Code Owners".
+
+/.github/                       @PhilipMathieu
+/docs/GOVERNANCE.md             @PhilipMathieu
+/src/maine_bills/schema.py      @PhilipMathieu
+/src/maine_bills/publish.py     @PhilipMathieu
+/pyproject.toml                 @PhilipMathieu
+/uv.lock                        @PhilipMathieu

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -9,11 +9,11 @@ This project is developed primarily by LLM agents with limited human oversight (
 A PR is Tier 1 if it touches **any** of the following:
 
 - **Publishing:** anything that uploads to HuggingFace Hub or otherwise makes data/artifacts public (including HF Space deploys).
-- **Dataset schema:** changes to `BillRecord` fields, parquet column layout, or dataset card structure.
-- **Governance:** this document.
-- **CI/workflows:** files under `.github/`.
+- **Dataset schema:** changes to `BillRecord` fields, parquet column layout, or dataset card structure (`src/maine_bills/schema.py`, `src/maine_bills/publish.py`).
+- **Governance:** this document and `.github/CODEOWNERS`.
+- **CI/workflows:** files under `.github/`, including action version pins.
 - **Secrets/credentials:** anything reading, writing, or configuring tokens and keys.
-- **Dependencies:** additions or removals in `pyproject.toml` (version bumps of existing deps are Tier 2).
+- **Dependencies:** additions or removals in `pyproject.toml`; any `uv.lock` change beyond the mechanical result of an approved `pyproject.toml` change; **major-version or security-sensitive bumps** of existing dependencies. (Minor/patch version bumps of existing deps are Tier 2.)
 
 **Marking:** title prefixed `[Tier-1]` and label `needs-human` (label optional if unavailable; the title prefix is authoritative). The PR description must include a short agent-written **risk summary**: one paragraph stating what is irreversible or outward-facing about the change and what was verified.
 
@@ -21,12 +21,17 @@ A PR is Tier 1 if it touches **any** of the following:
 
 ### Tier 2 — agent-review eligible
 
-Everything else: extraction/matching/scraper code, tests, refactors, docs (other than this file), bug fixes.
+Everything else: extraction/matching/scraper code, tests, refactors, docs (other than this file), bug fixes, minor/patch dependency bumps.
 
 **Requirements to merge:**
-1. CI green (unit tests + ruff).
+1. Required CI checks green: unit tests (`pytest -m "not integration"`) **and** lint (`ruff check`), as run by `.github/workflows/ci.yml`.
 2. An **independent agent review** — a reviewer session/agent that did not author the change reads the diff and approves. The author agent may not approve its own work.
-3. Title prefixed `[Tier-2]`; review recorded as a PR review or comment ending with the reviewer's verdict.
+3. The review is submitted as a formal GitHub PR review with an **Approve** verdict (not a free-form comment), containing this structured checklist:
+   - **Tier decision:** confirmed Tier 2, with one line on why no Tier-1 surface is touched.
+   - **Risk:** what could break and blast radius.
+   - **Checks:** tests/lint status and any manual verification performed.
+   - **Rollback:** how to revert (usually "revert commit"; note anything stateful).
+4. Title prefixed `[Tier-2]`.
 
 A human may always review, request changes on, or revert a Tier-2 PR; agent-merge authority is a default, not an exclusion.
 
@@ -34,9 +39,19 @@ A human may always review, request changes on, or revert a Tier-2 PR; agent-merg
 
 If an agent is unsure which tier applies, the PR is Tier 1. A PR that mixes tiers is Tier 1. Reviewers who discover hidden Tier-1 surface (e.g. a "test fix" that alters schema) re-label and stop the merge.
 
+## Enforcement (repo configuration)
+
+Policy is enforced by repository settings, not only by convention. `.github/CODEOWNERS` assigns the repo owner to all Tier-1 surfaces. The repo owner should configure (one-time, in Settings):
+
+- [ ] **Branch ruleset on `main`:** require a pull request before merging; require review from Code Owners; dismiss stale approvals on new pushes; block self-approval; require status checks `test` and `lint` (from `ci.yml`) to pass.
+- [ ] **Environment `huggingface-publish`:** required reviewer = repo owner; `HF_TOKEN` scoped to this environment only.
+- [ ] **Secret `OPENSTATES_API_KEY`** (repository secret) for matching jobs.
+
+With CODEOWNERS + ruleset in place, Tier-1 surfaces mechanically require the owner's review even if an agent mislabels a PR; the tier convention then governs everything the ruleset can't express (risk summaries, reviewer checklists, agent independence).
+
 ## The publish gate
 
-Dataset publishes run only through the `huggingface-publish` GitHub environment (required-reviewer protection), or by the repo owner locally. Agents never run `--publish` with a live token outside that gate.
+Dataset publishes run only through the `huggingface-publish` GitHub environment (required-reviewer protection), or by the repo owner locally. Agents never run `--publish` with a live token outside that gate. There is **no unattended scheduled publish path**: the weekly scheduled workflow produces artifacts and a diff summary, and the publish job waits on environment approval. (The pre-existing auto-publish in `scraper-uv.yml` is being retired in the CI workstream PR.)
 
 ## Human review tooling
 

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -26,7 +26,7 @@ Everything else: extraction/matching/scraper code, tests, refactors, docs (other
 **Requirements to merge:**
 1. Required CI checks green: unit tests (`pytest -m "not integration"`) **and** lint (`ruff check`), as run by `.github/workflows/ci.yml`.
 2. An **independent agent review** — a reviewer session/agent that did not author the change reads the diff and approves. The author agent may not approve its own work.
-3. The review is submitted as a formal GitHub PR review with an **Approve** verdict (not a free-form comment), containing this structured checklist:
+3. The review is submitted as a formal GitHub PR review with an **Approve** verdict, containing the structured checklist below. Mechanical caveat: agent sessions authenticate as the repo owner's account, and GitHub forbids Approve/Request-Changes events on one's own PRs — in that case the reviewer submits a comment-event PR review whose body opens with an explicit, unambiguous verdict line (**APPROVE** or **REQUEST CHANGES**); that verdict line is authoritative. Checklist:
    - **Tier decision:** confirmed Tier 2, with one line on why no Tier-1 surface is touched.
    - **Risk:** what could break and blast radius.
    - **Checks:** tests/lint status and any manual verification performed.

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,0 +1,47 @@
+# Governance: PR Approval Tiers
+
+This project is developed primarily by LLM agents with limited human oversight (~30 min/day). This document defines which changes require human approval and which can be approved by an independent agent review. It exists so that agents can merge safely without waiting on a human, while everything irreversible or outward-facing stays human-gated.
+
+## Tiers
+
+### Tier 1 — human approval required
+
+A PR is Tier 1 if it touches **any** of the following:
+
+- **Publishing:** anything that uploads to HuggingFace Hub or otherwise makes data/artifacts public (including HF Space deploys).
+- **Dataset schema:** changes to `BillRecord` fields, parquet column layout, or dataset card structure.
+- **Governance:** this document.
+- **CI/workflows:** files under `.github/`.
+- **Secrets/credentials:** anything reading, writing, or configuring tokens and keys.
+- **Dependencies:** additions or removals in `pyproject.toml` (version bumps of existing deps are Tier 2).
+
+**Marking:** title prefixed `[Tier-1]` and label `needs-human` (label optional if unavailable; the title prefix is authoritative). The PR description must include a short agent-written **risk summary**: one paragraph stating what is irreversible or outward-facing about the change and what was verified.
+
+**Merging:** only a human merges (or explicitly instructs an agent to merge) a Tier-1 PR.
+
+### Tier 2 — agent-review eligible
+
+Everything else: extraction/matching/scraper code, tests, refactors, docs (other than this file), bug fixes.
+
+**Requirements to merge:**
+1. CI green (unit tests + ruff).
+2. An **independent agent review** — a reviewer session/agent that did not author the change reads the diff and approves. The author agent may not approve its own work.
+3. Title prefixed `[Tier-2]`; review recorded as a PR review or comment ending with the reviewer's verdict.
+
+A human may always review, request changes on, or revert a Tier-2 PR; agent-merge authority is a default, not an exclusion.
+
+### Escalation rule
+
+If an agent is unsure which tier applies, the PR is Tier 1. A PR that mixes tiers is Tier 1. Reviewers who discover hidden Tier-1 surface (e.g. a "test fix" that alters schema) re-label and stop the merge.
+
+## The publish gate
+
+Dataset publishes run only through the `huggingface-publish` GitHub environment (required-reviewer protection), or by the repo owner locally. Agents never run `--publish` with a live token outside that gate.
+
+## Human review tooling
+
+For data-quality gates (match-rate reviews, backfill validation), agents provide a **sample-feedback UI** — a lightweight page showing extracted/enriched fields side-by-side with source evidence, with ✓/✗/flag verdicts saved as JSON that agents consume. Every review offers a **targeted** sample (low-confidence/edge cases) and a **random** sample (unbiased accuracy estimate). Verdicts become regression tests where applicable.
+
+## Daily queue discipline
+
+Agents never block mid-task on a human. Questions and Tier-1 approvals queue for the daily window, each with a one-paragraph risk summary. The daily window clears the whole queue, not just the oldest item.


### PR DESCRIPTION
## What

Adds `docs/GOVERNANCE.md`, the sprint's first deliverable: the convention separating PRs that require human approval (**Tier 1**: HF publishes, dataset schema, `.github/` workflows, secrets, dependency additions, this doc itself) from PRs an independent agent review can approve (**Tier 2**: everything else, with green CI plus a reviewer agent that did not author the change).

Also codifies: the escalation rule (unsure or mixed → Tier 1), the `huggingface-publish` environment as the only publish path, the sample-feedback UI convention for data-quality reviews (targeted + random samples, JSON verdicts), and daily queue discipline (agents queue rather than block on humans).

## Risk summary

Docs-only change — nothing executable. Its effect is procedural: once merged, agents will begin self-merging Tier-2 PRs after independent review, so the real decision here is whether the Tier-1 boundary as drafted covers everything you consider irreversible or outward-facing. Publishing, schema, CI, secrets, and dependencies are all inside the human gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WicqsC1r64bRg1pbAqFsTV)_