### PR TITLE
[Tier-1] ci: human-gated publishing, PR test workflow, data-run utility workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+# Plain CI: lint + unit tests on every PR and on pushes to main.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Ruff lint
+        run: uv run ruff check src/ tests/
+
+      - name: Unit tests
+        run: uv run pytest tests/ -v -m "not integration"

--- a/.github/workflows/data-run.yml
+++ b/.github/workflows/data-run.yml
@@ -1,0 +1,169 @@
+# Utility workflow: on-demand data tasks on GitHub runners.
+#
+# The sprint dev environment sits behind a proxy that only allows GitHub, so
+# anything that must reach huggingface.co, legislature.maine.gov, or
+# openstates.org runs here instead. Dispatch-only; never scheduled.
+name: Data Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Which task to run"
+        type: choice
+        required: true
+        default: fetch-status-sample
+        options:
+          - fetch-status-sample
+          - run-matching
+          - custom
+      sessions:
+        description: "Space-separated session numbers (e.g. '132')"
+        type: string
+        required: false
+        default: "132"
+      extra_args:
+        description: "Extra args (run-matching passthrough, or full command for 'custom': runs `uv run <extra_args>`)"
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  # Fetch ~25 bill status pages from the Maine Legislature site and stash the
+  # raw HTML on a fixtures branch so the network-restricted dev environment
+  # can develop parsers against real pages.
+  fetch-status-sample:
+    if: inputs.task == 'fetch-status-sample'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write # force-pushes the fixtures/status-pages-<session> branch
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Fetch status page sample
+        # The script probes candidate URL patterns first, then fetches with the
+        # winner at 1 req/sec. It always writes probe-results.json and exits 0
+        # so partial results still get committed/uploaded.
+        run: |
+          SESSION=$(echo "${{ inputs.sessions }}" | awk '{print $1}')
+          uv run python scripts/fetch_status_samples.py \
+            --session "$SESSION" --count 25 --out data/status-samples
+
+      - name: Commit fixtures branch
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          SESSION=$(echo "${{ inputs.sessions }}" | awk '{print $1}')
+          BRANCH="fixtures/status-pages-${SESSION}"
+          if [ ! -d data/status-samples ] || [ -z "$(ls -A data/status-samples 2>/dev/null)" ]; then
+            echo "Nothing fetched; skipping fixtures branch."
+            exit 0
+          fi
+          # Build an orphan (history-free) branch containing only the fixtures
+          # and force-push it; each run replaces the branch wholesale.
+          TMP="$(mktemp -d)"
+          cp -r data/status-samples/. "$TMP/"
+          cd "$TMP"
+          git init -b "$BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "fixtures: status pages for session ${SESSION} (data-run ${{ github.run_id }})"
+          git push --force \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/${BRANCH}"
+          echo "Pushed ${BRANCH}"
+
+      - name: Upload sample artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: status-samples
+          path: data/status-samples/
+          if-no-files-found: warn
+
+  # Run the sponsor-matching report (script being built on a parallel branch;
+  # skips cleanly if it hasn't merged yet). Expects the script to write its
+  # output under report/ (override via extra_args if its interface differs).
+  run-matching:
+    if: inputs.task == 'run-matching'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run matching report
+        env:
+          OPENSTATES_API_KEY: ${{ secrets.OPENSTATES_API_KEY }}
+        run: |
+          if [ -f scripts/run_matching_report.py ]; then
+            uv run python scripts/run_matching_report.py \
+              --sessions ${{ inputs.sessions }} ${{ inputs.extra_args }}
+          else
+            echo "::notice::scripts/run_matching_report.py not found on this ref (built on a parallel branch); skipping."
+            mkdir -p report
+            echo "run_matching_report.py not present on this ref; nothing was run." > report/SKIPPED.txt
+          fi
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: matching-report
+          path: report/
+          if-no-files-found: warn
+
+  # Escape hatch: run an arbitrary `uv run <extra_args>` command with full
+  # network access. Dispatch-only, so only collaborators with write access can
+  # trigger it; extra_args is interpolated into the shell deliberately.
+  custom:
+    if: inputs.task == 'custom'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run custom command
+        run: |
+          if [ -z "${{ inputs.extra_args }}" ]; then
+            echo "::error::task=custom requires extra_args (the command to run via 'uv run')."
+            exit 1
+          fi
+          uv run ${{ inputs.extra_args }}
+
+      - name: Upload output artifact (if any)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: custom-output
+          path: |
+            data/
+            report/
+          if-no-files-found: ignore

--- a/.github/workflows/data-run.yml
+++ b/.github/workflows/data-run.yml
@@ -118,7 +118,9 @@ jobs:
         run: |
           if [ -f scripts/run_matching_report.py ]; then
             uv run python scripts/run_matching_report.py \
-              --sessions ${{ inputs.sessions }} ${{ inputs.extra_args }}
+              --sessions ${{ inputs.sessions }} \
+              --parquet-source hf://datasets/pem207/maine-bills \
+              --output report ${{ inputs.extra_args }}
           else
             echo "::notice::scripts/run_matching_report.py not found on this ref (built on a parallel branch); skipping."
             mkdir -p report

--- a/.github/workflows/scraper-uv.yml
+++ b/.github/workflows/scraper-uv.yml
@@ -1,3 +1,16 @@
+# Weekly scrape + human-gated publish.
+#
+# Governance: publishes to HuggingFace are Tier-1 (human-approved). The scrape
+# job runs unattended and only produces a reviewable artifact; the publish job
+# is gated by the `huggingface-publish` GitHub environment.
+#
+# ONE-TIME REPO SETUP (owner, in GitHub Settings):
+#   1. Settings -> Environments -> New environment: `huggingface-publish`
+#   2. Enable "Required reviewers" and add yourself. This is the human gate --
+#      the publish job pauses until a reviewer approves the deployment.
+#   3. Add the `HF_TOKEN` secret (write token for pem207/maine-bills). Prefer
+#      adding it as an *environment* secret on `huggingface-publish` so it is
+#      only exposed to approved publish runs.
 name: Scrape and Publish
 
 on:
@@ -18,6 +31,9 @@ jobs:
   scrape:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions:
+      contents: read
+      actions: read # to download the previous run's artifact for the diff summary
 
     steps:
       - uses: actions/checkout@v4
@@ -31,9 +47,67 @@ jobs:
       - name: Run tests
         run: uv run pytest tests/ -v -m "not integration"
 
-      - name: Scrape and publish
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      - name: Scrape (no publish)
         run: |
           SESSIONS="${{ github.event.inputs.sessions || '132' }}"
-          uv run maine-bills --sessions $SESSIONS --publish
+          uv run maine-bills --sessions $SESSIONS --local-dir ./data
+
+      - name: Download previous run's artifact for diff (best effort)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREV_RUN=$(gh run list --repo "$GITHUB_REPOSITORY" \
+            --workflow "scraper-uv.yml" --status success --limit 1 \
+            --json databaseId --jq '.[0].databaseId' || true)
+          if [ -n "$PREV_RUN" ]; then
+            echo "Previous successful run: $PREV_RUN"
+            gh run download "$PREV_RUN" --repo "$GITHUB_REPOSITORY" \
+              --name scraped-parquet --dir previous \
+              || echo "No 'scraped-parquet' artifact on previous run (expired or first refactored run)"
+          else
+            echo "No previous successful run found"
+          fi
+
+      - name: Write job summary
+        run: |
+          uv run python scripts/scrape_summary.py \
+            --data-dir data --previous-dir previous >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload parquet artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scraped-parquet
+          path: data/
+          if-no-files-found: error
+          retention-days: 90
+
+  # Human gate: this job waits for a required reviewer on the
+  # `huggingface-publish` environment before it starts (see header comment).
+  # It publishes exactly the parquet files produced (and reviewable) above --
+  # no re-scrape between review and publish.
+  publish:
+    needs: scrape
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: huggingface-publish
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Download scraped parquet
+        uses: actions/download-artifact@v4
+        with:
+          name: scraped-parquet
+          path: data/
+
+      - name: Publish to HuggingFace
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: uv run python scripts/publish_from_artifact.py --data-dir data

--- a/scripts/fetch_status_samples.py
+++ b/scripts/fetch_status_samples.py
@@ -1,0 +1,217 @@
+"""Fetch a sample of Maine Legislature bill *status* pages as parser fixtures.
+
+The bill PDFs come from lldc.mainelegislature.org (see BillScraper), but the
+legislative-history / status pages live elsewhere on legislature.maine.gov and
+their exact URL scheme is not verifiable from the network-restricted dev
+environment. So this script works in two phases:
+
+1. Probe: try several candidate URL patterns for LD 1 (and confirm with LD 2,
+   to rule out soft-404 pages that return 200 for anything) and record every
+   response in probe-results.json.
+2. Fetch: use the winning pattern to download status pages for LD 1..N at
+   1 request/second with a descriptive User-Agent.
+
+It degrades gracefully: any probe/fetch failure is recorded, whatever HTML was
+retrieved is kept, probe-results.json is always written, and the exit code is
+0 so CI can still upload partial results.
+
+Usage:
+    uv run python scripts/fetch_status_samples.py --session 132 --count 25 \
+        --out data/status-samples
+    uv run python scripts/fetch_status_samples.py --session 132 --probe-only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+USER_AGENT = (
+    "maine-bills-fixture-fetcher/1.0 "
+    "(+https://github.com/PhilipMathieu/maine-bills; research dataset tooling)"
+)
+
+# Candidate URL patterns for a bill status page, in priority order.
+# Assumptions (unverified from the dev environment -- hence the probe):
+#   - `display_ps.asp?LD=<n>&snum=<session>` is the historical "paper status"
+#     page under /legis/bills/ on both legislature.maine.gov and
+#     www.mainelegislature.org.
+#   - LawMakerWeb summary.asp normally takes an opaque ID, but some deployments
+#     accept LD/session query params; included as a long-shot fallback.
+CANDIDATE_PATTERNS: list[str] = [
+    "https://legislature.maine.gov/legis/bills/display_ps.asp?LD={ld}&snum={session}",
+    "https://www.mainelegislature.org/legis/bills/display_ps.asp?LD={ld}&snum={session}",
+    "https://legislature.maine.gov/bills/display_ps.asp?LD={ld}&snum={session}",
+    "https://legislature.maine.gov/LawMakerWeb/summary.asp?LD={ld}&SessionID={session}",
+]
+
+REQUEST_TIMEOUT = 30
+MIN_PLAUSIBLE_LENGTH = 500  # bytes of HTML below which a page is likely an error stub
+
+
+def build_url(pattern: str, session: int, ld: int) -> str:
+    return pattern.format(session=session, ld=ld)
+
+
+def fetch_page(url: str, http: requests.Session) -> dict:
+    """GET one URL; return a result record (never raises)."""
+    record: dict = {"url": url, "ok": False, "status": None, "length": 0, "error": None}
+    try:
+        res = http.get(url, timeout=REQUEST_TIMEOUT)
+        record["status"] = res.status_code
+        record["length"] = len(res.content)
+        record["content_type"] = res.headers.get("Content-Type", "")
+        if res.status_code == 200:
+            record["ok"] = True
+            record["text"] = res.text
+    except requests.RequestException as e:
+        record["error"] = f"{type(e).__name__}: {e}"
+    return record
+
+
+def looks_like_status_page(record: dict, ld: int) -> bool:
+    """Heuristic: 200 HTML of plausible size that mentions the LD number."""
+    if not record.get("ok"):
+        return False
+    if "html" not in record.get("content_type", "").lower():
+        return False
+    text = record.get("text", "")
+    if len(text) < MIN_PLAUSIBLE_LENGTH:
+        return False
+    return re.search(rf"\bLD\s*0*{ld}\b", text, re.IGNORECASE) is not None
+
+
+def probe(session: int, http: requests.Session, delay: float) -> tuple[str | None, list[dict]]:
+    """Try each candidate pattern for LD 1; confirm the winner with LD 2.
+
+    Returns (winning_pattern_or_None, probe_records).
+    """
+    records: list[dict] = []
+    winner: str | None = None
+
+    for pattern in CANDIDATE_PATTERNS:
+        rec = fetch_page(build_url(pattern, session, 1), http)
+        rec["pattern"] = pattern
+        rec["ld"] = 1
+        rec["plausible"] = looks_like_status_page(rec, 1)
+        text_ld1 = rec.pop("text", "")
+        records.append(rec)
+        time.sleep(delay)
+
+        if not rec["plausible"] or winner is not None:
+            continue
+
+        # Confirm with LD 2: content must also be plausible AND differ from
+        # LD 1's, otherwise this is likely a soft-404 that 200s on anything.
+        rec2 = fetch_page(build_url(pattern, session, 2), http)
+        rec2["pattern"] = pattern
+        rec2["ld"] = 2
+        rec2["plausible"] = looks_like_status_page(rec2, 2)
+        text_ld2 = rec2.pop("text", "")
+        rec2["differs_from_ld1"] = text_ld2 != text_ld1
+        records.append(rec2)
+        time.sleep(delay)
+
+        if rec2["plausible"] and rec2["differs_from_ld1"]:
+            winner = pattern
+
+    return winner, records
+
+
+def fetch_samples(
+    pattern: str,
+    session: int,
+    count: int,
+    out_dir: Path,
+    http: requests.Session,
+    delay: float,
+) -> list[dict]:
+    """Fetch status pages for LD 1..count, saving HTML files; returns records."""
+    results: list[dict] = []
+    for ld in range(1, count + 1):
+        rec = fetch_page(build_url(pattern, session, ld), http)
+        rec["ld"] = ld
+        rec["plausible"] = looks_like_status_page(rec, ld)
+        text = rec.pop("text", None)
+        if rec["ok"] and text:
+            path = out_dir / f"LD-{ld:04d}.html"
+            path.write_text(text, encoding="utf-8")
+            rec["file"] = path.name
+        results.append(rec)
+        status = rec["status"] if rec["status"] is not None else rec["error"]
+        print(f"LD {ld}: {status} ({rec['length']} bytes)")
+        time.sleep(delay)
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--session", type=int, default=132, help="Legislative session number")
+    parser.add_argument("--count", type=int, default=25, help="Number of LDs to sample (1..N)")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("data/status-samples"),
+        help="Output directory for HTML files and probe-results.json",
+    )
+    parser.add_argument(
+        "--probe-only",
+        action="store_true",
+        help="Only probe candidate URL patterns; skip the sample fetch",
+    )
+    parser.add_argument(
+        "--delay", type=float, default=1.0, help="Seconds between requests (be polite)"
+    )
+    args = parser.parse_args()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    http = requests.Session()
+    http.headers.update({"User-Agent": USER_AGENT})
+
+    output: dict = {
+        "session": args.session,
+        "count_requested": args.count,
+        "candidate_patterns": CANDIDATE_PATTERNS,
+        "winning_pattern": None,
+        "probe": [],
+        "fetch": [],
+    }
+
+    try:
+        winner, probe_records = probe(args.session, http, args.delay)
+        output["probe"] = probe_records
+        output["winning_pattern"] = winner
+
+        if winner is None:
+            print("PROBE FAILED: no candidate URL pattern produced a plausible status page.")
+            print("See probe-results.json for per-pattern responses.")
+        else:
+            print(f"Winning pattern: {winner}")
+            if not args.probe_only:
+                output["fetch"] = fetch_samples(
+                    winner, args.session, args.count, args.out, http, args.delay
+                )
+                fetched = sum(1 for r in output["fetch"] if r.get("file"))
+                print(f"Fetched {fetched}/{args.count} pages into {args.out}")
+    except Exception as e:  # noqa: BLE001 -- degrade gracefully, always write results
+        output["fatal_error"] = f"{type(e).__name__}: {e}"
+        print(f"Unexpected error: {e}", file=sys.stderr)
+    finally:
+        results_path = args.out / "probe-results.json"
+        results_path.write_text(json.dumps(output, indent=2), encoding="utf-8")
+        print(f"Wrote {results_path}")
+
+    # Always exit 0 so CI uploads whatever was collected; probe-results.json
+    # carries the success/failure detail.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/publish_from_artifact.py
+++ b/scripts/publish_from_artifact.py
@@ -1,0 +1,88 @@
+"""Publish previously scraped parquet files to HuggingFace Hub.
+
+Used by the human-gated `publish` job in scraper-uv.yml: the scrape job writes
+<data_dir>/<session>/*.parquet and uploads it as an artifact; after a reviewer
+approves the `huggingface-publish` environment, this script uploads exactly
+those files (no re-scrape between review and publish).
+
+Requires HF_TOKEN in the environment (huggingface_hub picks it up).
+
+Usage:
+    uv run python scripts/publish_from_artifact.py --data-dir data
+    uv run python scripts/publish_from_artifact.py --data-dir data --sessions 131 132
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from maine_bills.publish import publish_session, sync_dataset_card
+
+
+def discover_sessions(data_dir: Path) -> list[int]:
+    """Find session numbers with parquet files under <data_dir>/<session>/."""
+    return sorted(
+        int(d.name)
+        for d in data_dir.iterdir()
+        if d.is_dir() and d.name.isdigit() and any(d.glob("*.parquet"))
+    )
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s:%(levelname)s:%(message)s",
+        stream=sys.stdout,
+    )
+    logger = logging.getLogger("publish_from_artifact")
+
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--data-dir", type=Path, required=True)
+    parser.add_argument(
+        "--repo-id",
+        default="pem207/maine-bills",
+        help="HuggingFace dataset repo ID (default: pem207/maine-bills)",
+    )
+    parser.add_argument(
+        "--sessions",
+        nargs="+",
+        type=int,
+        default=None,
+        metavar="SESSION",
+        help="Sessions to publish (default: every session dir found in --data-dir)",
+    )
+    args = parser.parse_args()
+
+    if not args.data_dir.is_dir():
+        logger.error(f"Data dir not found: {args.data_dir}")
+        return 1
+
+    sessions = args.sessions or discover_sessions(args.data_dir)
+    if not sessions:
+        logger.error(f"No session parquet files found under {args.data_dir}")
+        return 1
+
+    try:
+        for session in sessions:
+            parts = sorted((args.data_dir / str(session)).glob("*.parquet"))
+            if not parts:
+                logger.error(f"No parquet files for session {session}; aborting")
+                return 1
+            df = pd.concat([pd.read_parquet(p) for p in parts], ignore_index=True)
+            logger.info(f"Publishing session {session}: {len(df)} records")
+            publish_session(df, session, args.repo_id, args.data_dir)
+
+        sync_dataset_card(args.repo_id)
+        return 0
+    except Exception as e:
+        logger.error(f"Publish failed: {e}", exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/scrape_summary.py
+++ b/scripts/scrape_summary.py
@@ -1,0 +1,110 @@
+"""Write a Markdown summary of a scrape run (for $GITHUB_STEP_SUMMARY).
+
+Reads parquet files laid out as <data_dir>/<session>/*.parquet, prints per-
+session record counts, and -- if a previous run's artifact is available under
+--previous-dir -- a cheap diff (new / removed / changed documents keyed by
+source_filename, changed = same filename with different text).
+
+Usage:
+    uv run python scripts/scrape_summary.py --data-dir data --previous-dir previous
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+def load_session_frames(data_dir: Path) -> dict[int, pd.DataFrame]:
+    """Map session number -> DataFrame for every <data_dir>/<session>/*.parquet."""
+    frames: dict[int, pd.DataFrame] = {}
+    if not data_dir.is_dir():
+        return frames
+    for session_dir in sorted(data_dir.iterdir()):
+        if not (session_dir.is_dir() and session_dir.name.isdigit()):
+            continue
+        parts = sorted(session_dir.glob("*.parquet"))
+        if parts:
+            frames[int(session_dir.name)] = pd.concat(
+                [pd.read_parquet(p) for p in parts], ignore_index=True
+            )
+    return frames
+
+
+def diff_counts(current: pd.DataFrame, previous: pd.DataFrame) -> tuple[int, int, int]:
+    """Return (new, removed, changed) document counts keyed by source_filename."""
+    cur = current.set_index("source_filename")["text"]
+    prev = previous.set_index("source_filename")["text"]
+    new = len(cur.index.difference(prev.index))
+    removed = len(prev.index.difference(cur.index))
+    common = cur.index.intersection(prev.index)
+    changed = int((cur.loc[common] != prev.loc[common]).sum())
+    return new, removed, changed
+
+
+def build_summary(data_dir: Path, previous_dir: Path | None) -> str:
+    """Build the Markdown job summary."""
+    current = load_session_frames(data_dir)
+    previous = load_session_frames(previous_dir) if previous_dir else {}
+
+    lines = ["## Scrape summary", ""]
+    if not current:
+        lines.append(f"No parquet files found under `{data_dir}` -- scrape produced nothing.")
+        return "\n".join(lines) + "\n"
+
+    have_diff = bool(previous)
+    if have_diff:
+        lines.append("| Session | Records | Originals | Amendments | New | Removed | Changed |")
+        lines.append("|---|---|---|---|---|---|---|")
+    else:
+        lines.append("| Session | Records | Originals | Amendments |")
+        lines.append("|---|---|---|---|")
+
+    total = 0
+    for session, df in sorted(current.items()):
+        total += len(df)
+        amendments = int(df["amendment_code"].notna().sum())
+        originals = len(df) - amendments
+        row = f"| {session} | {len(df)} | {originals} | {amendments} |"
+        if have_diff:
+            if session in previous:
+                new, removed, changed = diff_counts(df, previous[session])
+                row += f" {new} | {removed} | {changed} |"
+            else:
+                row += " - | - | - |"
+        lines.append(row)
+
+    lines.append("")
+    lines.append(f"**Total: {total} records across {len(current)} session(s).**")
+    if not have_diff:
+        lines.append("")
+        lines.append("_No previous-run artifact available; skipping new/changed diff._")
+    lines.append("")
+    lines.append(
+        "Parquet uploaded as the `scraped-parquet` artifact. Publishing to "
+        "HuggingFace requires approval on the `huggingface-publish` environment."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--data-dir", type=Path, required=True)
+    parser.add_argument(
+        "--previous-dir",
+        type=Path,
+        default=None,
+        help="Previous run's artifact dir (optional; diff is skipped if missing)",
+    )
+    args = parser.parse_args()
+
+    previous_dir = args.previous_dir if args.previous_dir and args.previous_dir.is_dir() else None
+    print(build_summary(args.data_dir, previous_dir))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -538,9 +538,13 @@ class TextExtractor:
         # Scanned-PDF session header lines (appear after line-number stripping)
         if re.match(r'^HOUSE OF REPRESENTATIVES\s*$', line_stripped, re.IGNORECASE):
             return True
-        if re.match(r'^\d+(?:ST|ND|RD|TH)\s+(?:MAINE\s+)?LEGISLATURE\s*$', line_stripped, re.IGNORECASE):
+        if re.match(
+            r'^\d+(?:ST|ND|RD|TH)\s+(?:MAINE\s+)?LEGISLATURE\s*$', line_stripped, re.IGNORECASE
+        ):
             return True
-        if re.match(r'^(?:FIRST|SECOND|THIRD)\s+(?:REGULAR|SPECIAL)\s+SESSION', line_stripped, re.IGNORECASE):
+        if re.match(
+            r'^(?:FIRST|SECOND|THIRD)\s+(?:REGULAR|SPECIAL)\s+SESSION', line_stripped, re.IGNORECASE
+        ):
             return True
 
         return False

--- a/tests/unit/test_scrape_summary.py
+++ b/tests/unit/test_scrape_summary.py
@@ -1,0 +1,77 @@
+"""Unit tests for scripts/scrape_summary.py (CI job-summary generator)."""
+
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "scrape_summary.py"
+
+spec = importlib.util.spec_from_file_location("scrape_summary", SCRIPT_PATH)
+scrape_summary = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scrape_summary)
+
+
+def _write_session(data_dir: Path, session: int, rows: list[dict]) -> None:
+    session_dir = data_dir / str(session)
+    session_dir.mkdir(parents=True)
+    pd.DataFrame(rows).to_parquet(session_dir / "train-00000-of-00001.parquet", index=False)
+
+
+def _rows(*specs: tuple[str, str, str | None]) -> list[dict]:
+    """Each spec is (source_filename, text, amendment_code)."""
+    return [
+        {"source_filename": f, "text": t, "amendment_code": a}
+        for f, t, a in specs
+    ]
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    d = tmp_path / "data"
+    _write_session(
+        d,
+        132,
+        _rows(
+            ("132-LD-0001", "text one", None),
+            ("132-LD-0002", "text two", None),
+            ("132-LD-0002-CA_A_H0001", "amend text", "CA_A_H0001"),
+        ),
+    )
+    return d
+
+
+def test_counts_without_previous(data_dir):
+    summary = scrape_summary.build_summary(data_dir, None)
+    assert "| 132 | 3 | 2 | 1 |" in summary
+    assert "Total: 3 records across 1 session(s)" in summary
+    assert "No previous-run artifact" in summary
+
+
+def test_diff_against_previous(data_dir, tmp_path):
+    prev = tmp_path / "previous"
+    _write_session(
+        prev,
+        132,
+        _rows(
+            ("132-LD-0001", "text one", None),  # unchanged
+            ("132-LD-0002", "OLD text two", None),  # changed
+            ("132-LD-9999", "gone", None),  # removed
+        ),
+    )
+    summary = scrape_summary.build_summary(data_dir, prev)
+    # new=1 (the amendment), removed=1 (LD-9999), changed=1 (LD-0002)
+    assert "| 132 | 3 | 2 | 1 | 1 | 1 | 1 |" in summary
+
+
+def test_empty_data_dir(tmp_path):
+    summary = scrape_summary.build_summary(tmp_path / "nope", None)
+    assert "scrape produced nothing" in summary
+
+
+def test_previous_session_missing_shows_dashes(data_dir, tmp_path):
+    prev = tmp_path / "previous"
+    _write_session(prev, 131, _rows(("131-LD-0001", "x", None)))
+    summary = scrape_summary.build_summary(data_dir, prev)
+    assert "| 132 | 3 | 2 | 1 | - | - | - |" in summary


### PR DESCRIPTION
## What

Three CI changes that turn GitHub Actions into the sprint's execution plane and close the ungated-publish hole:

1. **`scraper-uv.yml` refactored** — the weekly cron no longer auto-publishes. The `scrape` job runs tests, scrapes without `--publish`, writes a job summary (per-session counts + new/removed/changed diff vs the previous run's artifact, best-effort), and uploads the parquet as a 90-day artifact. A separate `publish` job, gated by the **`huggingface-publish` environment**, downloads that exact reviewed artifact and publishes it verbatim (`scripts/publish_from_artifact.py`) — no re-scrape between review and publish. `HF_TOKEN` is referenced only in the publish job.
2. **`ci.yml` (new)** — `ruff check src/ tests/` + `pytest -m "not integration"` on every PR and push to main. These become the required `test`/`lint` checks named in GOVERNANCE.md. (Lint scope excludes `scripts/` because pre-existing demo scripts fail ruff; the three new scripts pass individually.)
3. **`data-run.yml` (new)** — dispatch-only utility workflow, the escape hatch for the network-restricted dev environment: `fetch-status-sample` (polite 1 req/s probe of candidate status-page URL patterns for a session, commits raw HTML fixtures to an orphan `fixtures/status-pages-<session>` branch + artifact, always records `probe-results.json`), `run-matching` (runs the matching report script from the parallel branch once merged; graceful skip until then), and `custom` (ad-hoc `uv run` command). `contents: write` granted only to the fixtures job.

155 unit tests pass (4 new for the summary script), workflows validated as YAML, ruff clean on new scripts.

## ⚠️ Merge-ordering requirement

**Configure the environment before merging** (or at least before the next Sunday 06:00 UTC cron): Settings → Environments → new environment `huggingface-publish` → enable **Required reviewers** (add yourself) → move `HF_TOKEN` there as an environment secret. Until that exists, the `publish` job would run ungated after each scrape — same exposure as the current workflow on `main`, but the point of this PR is to end that. Optional: add `OPENSTATES_API_KEY` repo secret for `run-matching` (degrades to keyless if absent).

## Risk summary

Outward-facing surface: HF publishing behavior and repo CI. The publish path gets strictly safer once the environment is configured (human approval + reviewed-artifact publishing instead of unattended scrape-and-push), but the gate lives in repo settings, not in this diff — hence the merge-ordering note above. The fixtures job force-pushes only to `fixtures/*` branches. The probe script's status-page URL patterns are educated guesses recorded in `probe-results.json`; a failed probe run still exits green and uploads diagnostics rather than failing the workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WicqsC1r64bRg1pbAqFsTV)_