### PR TITLE
[Tier-1] feat: dataset schema v2 — sponsor enrichment fields + integration point

### DIFF
--- a/src/maine_bills/cli.py
+++ b/src/maine_bills/cli.py
@@ -38,6 +38,16 @@ def build_parser() -> argparse.ArgumentParser:
         default=8,
         help="Number of parallel download workers (default: 8)",
     )
+    parser.add_argument(
+        "--enrich",
+        action="store_true",
+        help=(
+            "Enrich sponsors against the OpenStates roster (v2 fields: "
+            "sponsor_ids, sponsor_parties, sponsor_districts, "
+            "sponsor_match_confidence); no-ops with a warning if the "
+            "matching module/data is unavailable"
+        ),
+    )
     return parser
 
 
@@ -51,14 +61,26 @@ def main() -> int:
 
     args = build_parser().parse_args()
 
+    matcher_fn = None
+    if args.enrich:
+        from .enrichment import load_matcher
+
+        matcher_fn = load_matcher(logger)
+
     try:
         for session in args.sessions:
             scraper = BillScraper(session, workers=args.workers, logger=logger)
             df = scraper.scrape_session()
             logger.info(f"Session {session}: {len(df)} records")
 
+            if matcher_fn is not None:
+                from .enrichment import enrich_dataframe
+
+                df = enrich_dataframe(df, matcher_fn)
+
             if args.publish:
                 from .publish import publish_session, sync_dataset_card
+
                 publish_session(df, session, args.repo_id, args.local_dir)
             else:
                 out_dir = args.local_dir / str(session)
@@ -69,6 +91,7 @@ def main() -> int:
 
         if args.publish:
             from .publish import sync_dataset_card
+
             sync_dataset_card(args.repo_id)
 
         return 0

--- a/src/maine_bills/enrichment.py
+++ b/src/maine_bills/enrichment.py
@@ -1,0 +1,155 @@
+"""Sponsor enrichment integration point (dataset schema v2).
+
+Applies sponsor match results to BillRecords / DataFrames without depending on
+any particular matcher implementation. A matcher is any callable with the
+contract:
+
+    matcher_fn(sponsors: list[str]) -> list[Match | dict | None]
+
+where the returned list is aligned index-wise with the input `sponsors` list,
+None marks an unmatched sponsor, and each match (attribute-style object or
+dict) provides: openstates_id, canonical_name, party, district, confidence,
+method.
+
+The default matcher is loaded lazily from ``maine_bills.sponsor_matching``
+(built separately); if that module is unavailable, enrichment no-ops with a
+warning so the v1 pipeline keeps working unchanged.
+"""
+
+import inspect
+import logging
+
+import pandas as pd
+
+from .schema import BillRecord
+
+logger = logging.getLogger(__name__)
+
+# Attribute/key names a match object or dict must provide
+MATCH_FIELDS = ("openstates_id", "canonical_name", "party", "district", "confidence", "method")
+
+
+def _match_value(match, name: str):
+    """Read a field from a match, supporting both objects and dicts."""
+    if isinstance(match, dict):
+        return match.get(name)
+    return getattr(match, name, None)
+
+
+def apply_enrichment(record: BillRecord, matches: list) -> BillRecord:
+    """Apply sponsor match results to a BillRecord in place.
+
+    The original `sponsors` strings are never modified (provenance); only the
+    four v2 enrichment fields are populated.
+
+    Args:
+        record: BillRecord to enrich
+        matches: List aligned index-wise with record.sponsors. Each entry is
+                 either None (unmatched) or a match object/dict exposing
+                 openstates_id, party, district, and confidence.
+
+    Returns:
+        The same BillRecord, with sponsor_ids, sponsor_parties,
+        sponsor_districts, and sponsor_match_confidence populated
+        (None entries where unmatched).
+
+    Raises:
+        ValueError: If len(matches) != len(record.sponsors)
+    """
+    if len(matches) != len(record.sponsors):
+        raise ValueError(
+            f"Got {len(matches)} matches for {len(record.sponsors)} sponsors; "
+            "matches must align index-wise with sponsors"
+        )
+
+    record.sponsor_ids = [
+        _match_value(m, "openstates_id") if m is not None else None for m in matches
+    ]
+    record.sponsor_parties = [_match_value(m, "party") if m is not None else None for m in matches]
+    record.sponsor_districts = [
+        _match_value(m, "district") if m is not None else None for m in matches
+    ]
+    record.sponsor_match_confidence = [
+        _match_value(m, "confidence") if m is not None else None for m in matches
+    ]
+    return record
+
+
+def enrich_dataframe(df: pd.DataFrame, matcher_fn) -> pd.DataFrame:
+    """Populate the v2 enrichment columns of a scraped DataFrame.
+
+    Args:
+        df: DataFrame of BillRecord rows (must have `session` and `sponsors`
+            columns; enrichment columns are created if absent)
+        matcher_fn: Callable taking a list of sponsor name strings and
+                    returning an aligned list of match objects/dicts (with
+                    openstates_id, party, district, confidence) or None for
+                    unmatched names. Also receives the record's session as a
+                    `session` keyword argument if it accepts one.
+
+    Returns:
+        The same DataFrame with sponsor_ids, sponsor_parties,
+        sponsor_districts, and sponsor_match_confidence columns filled.
+    """
+    if df.empty:
+        return df
+
+    params = inspect.signature(matcher_fn).parameters
+    accepts_session = "session" in params or any(p.kind == p.VAR_KEYWORD for p in params.values())
+
+    ids_col, parties_col, districts_col, confidence_col = [], [], [], []
+    matched = total = 0
+
+    for _, row in df.iterrows():
+        sponsors = list(row["sponsors"])
+        if accepts_session:
+            matches = matcher_fn(sponsors, session=row["session"])
+        else:
+            matches = matcher_fn(sponsors)
+        if len(matches) != len(sponsors):
+            raise ValueError(
+                f"Matcher returned {len(matches)} matches for {len(sponsors)} sponsors"
+            )
+        ids_col.append([_match_value(m, "openstates_id") if m else None for m in matches])
+        parties_col.append([_match_value(m, "party") if m else None for m in matches])
+        districts_col.append([_match_value(m, "district") if m else None for m in matches])
+        confidence_col.append([_match_value(m, "confidence") if m else None for m in matches])
+        total += len(sponsors)
+        matched += sum(1 for m in matches if m is not None)
+
+    df["sponsor_ids"] = ids_col
+    df["sponsor_parties"] = parties_col
+    df["sponsor_districts"] = districts_col
+    df["sponsor_match_confidence"] = confidence_col
+
+    if total:
+        logger.info(f"Enriched {matched}/{total} sponsor mentions ({matched / total:.1%})")
+    return df
+
+
+def load_matcher(logger_: logging.Logger | None = None):
+    """Load the default matcher from maine_bills.sponsor_matching, if available.
+
+    Returns:
+        A matcher_fn suitable for enrich_dataframe(), or None (with a warning)
+        if the sponsor_matching module or its match function is unavailable —
+        callers should treat None as "skip enrichment".
+    """
+    log = logger_ or logger
+    try:
+        from . import sponsor_matching
+    except ImportError:
+        log.warning(
+            "Sponsor enrichment unavailable: maine_bills.sponsor_matching not found; "
+            "skipping --enrich (records keep null enrichment fields)"
+        )
+        return None
+
+    matcher_fn = getattr(sponsor_matching, "match_sponsors", None)
+    if matcher_fn is None:
+        log.warning(
+            "Sponsor enrichment unavailable: sponsor_matching.match_sponsors not found; "
+            "skipping --enrich (records keep null enrichment fields)"
+        )
+        return None
+    return matcher_fn

--- a/src/maine_bills/enrichment.py
+++ b/src/maine_bills/enrichment.py
@@ -94,8 +94,15 @@ def enrich_dataframe(df: pd.DataFrame, matcher_fn) -> pd.DataFrame:
     if df.empty:
         return df
 
-    params = inspect.signature(matcher_fn).parameters
-    accepts_session = "session" in params or any(p.kind == p.VAR_KEYWORD for p in params.values())
+    try:
+        params = inspect.signature(matcher_fn).parameters
+        accepts_session = "session" in params or any(
+            p.kind == p.VAR_KEYWORD for p in params.values()
+        )
+    except (TypeError, ValueError):
+        # Some callables (e.g. C-implemented) aren't introspectable; assume the
+        # simpler contract rather than aborting enrichment.
+        accepts_session = False
 
     ids_col, parties_col, districts_col, confidence_col = [], [], [], []
     matched = total = 0
@@ -110,10 +117,16 @@ def enrich_dataframe(df: pd.DataFrame, matcher_fn) -> pd.DataFrame:
             raise ValueError(
                 f"Matcher returned {len(matches)} matches for {len(sponsors)} sponsors"
             )
-        ids_col.append([_match_value(m, "openstates_id") if m else None for m in matches])
-        parties_col.append([_match_value(m, "party") if m else None for m in matches])
-        districts_col.append([_match_value(m, "district") if m else None for m in matches])
-        confidence_col.append([_match_value(m, "confidence") if m else None for m in matches])
+        ids_col.append(
+            [_match_value(m, "openstates_id") if m is not None else None for m in matches]
+        )
+        parties_col.append([_match_value(m, "party") if m is not None else None for m in matches])
+        districts_col.append(
+            [_match_value(m, "district") if m is not None else None for m in matches]
+        )
+        confidence_col.append(
+            [_match_value(m, "confidence") if m is not None else None for m in matches]
+        )
         total += len(sponsors)
         matched += sum(1 for m in matches if m is not None)
 

--- a/src/maine_bills/publish.py
+++ b/src/maine_bills/publish.py
@@ -79,10 +79,10 @@ endorsed by nor affiliated with the Maine State Legislature.
 | `text` | string | Full extracted text of the document |
 | `title` | string | Bill title extracted from content, or null |
 | `sponsors` | list | Sponsor names extracted from content (verbatim; provenance) |
-| `sponsor_ids` | list | OpenStates person IDs, aligned with `sponsors`; null if unmatched |
-| `sponsor_parties` | list | Party affiliations, aligned with `sponsors`; null if unmatched |
-| `sponsor_districts` | list | Legislative districts, aligned with `sponsors`; null if unmatched |
-| `sponsor_match_confidence` | list | Match confidence (0-1), aligned with `sponsors`; or null |
+| `sponsor_ids` | list | OpenStates person IDs, aligned with `sponsors`; nulls where unmatched |
+| `sponsor_parties` | list | Party affiliations, aligned with `sponsors`; nulls where unmatched |
+| `sponsor_districts` | list | Districts, aligned with `sponsors`; nulls where unmatched |
+| `sponsor_match_confidence` | list | Confidence 0-1, aligned; nulls where unmatched |
 | `committee` | string | Referred committee, or null |
 | `source_url` | string | Direct URL to the original PDF |
 | `source_filename` | string | Original filename without extension |

--- a/src/maine_bills/publish.py
+++ b/src/maine_bills/publish.py
@@ -38,6 +38,13 @@ configs:
 Full text of bills and amendments from the Maine State Legislature,
 extracted from PDFs published by the Law and Legislative Reference Library.
 
+**Dataset version: v2.** Adds four nullable sponsor-enrichment columns
+(`sponsor_ids`, `sponsor_parties`, `sponsor_districts`,
+`sponsor_match_confidence`) linking extracted sponsor names to OpenStates
+legislator records. All v1 columns are unchanged, so existing consumers are
+unaffected; records scraped without enrichment carry null entries in the new
+columns.
+
 ## Usage
 
 ```python
@@ -71,11 +78,36 @@ endorsed by nor affiliated with the Maine State Legislature.
 | `chamber` | string | House or Senate (derived from amendment) or null |
 | `text` | string | Full extracted text of the document |
 | `title` | string | Bill title extracted from content, or null |
-| `sponsors` | list | Sponsor names extracted from content |
+| `sponsors` | list | Sponsor names extracted from content (verbatim; provenance) |
+| `sponsor_ids` | list | OpenStates person IDs, aligned with `sponsors`; null if unmatched |
+| `sponsor_parties` | list | Party affiliations, aligned with `sponsors`; null if unmatched |
+| `sponsor_districts` | list | Legislative districts, aligned with `sponsors`; null if unmatched |
+| `sponsor_match_confidence` | list | Match confidence (0-1), aligned with `sponsors`; or null |
 | `committee` | string | Referred committee, or null |
 | `source_url` | string | Direct URL to the original PDF |
 | `source_filename` | string | Original filename without extension |
 | `scraped_at` | string | ISO 8601 timestamp of extraction |
+
+The four `sponsor_*` enrichment columns are index-aligned with `sponsors`:
+entry *i* of each list describes `sponsors[i]`. `sponsors` itself is always
+the verbatim extracted name and is never rewritten by enrichment.
+
+## Sponsor enrichment methodology
+
+Extracted sponsor names are matched against the OpenStates roster of Maine
+legislators for the corresponding session using two-pass matching:
+
+1. **Exact pass:** the extracted name is normalized (case-folded, whitespace
+   and punctuation collapsed) and matched on last name against the roster.
+   Unambiguous exact matches are accepted with confidence 1.0.
+2. **Fuzzy fallback:** names not resolved by the exact pass are scored with
+   rapidfuzz string similarity against roster names; the best candidate is
+   accepted only above a similarity threshold, with the normalized score
+   recorded in `sponsor_match_confidence`.
+
+Sponsors that fail both passes are left null in all four enrichment columns —
+no match is ever forced. The original extracted string in `sponsors` is kept
+untouched as provenance either way.
 
 ## License
 
@@ -110,9 +142,7 @@ def sync_dataset_card(repo_id: str) -> None:
 
     repo_items = api.list_repo_tree(repo_id, repo_type="dataset", path_in_repo="data")
     sessions = sorted(
-        int(item.path.split("/")[-1])
-        for item in repo_items
-        if item.path.split("/")[-1].isdigit()
+        int(item.path.split("/")[-1]) for item in repo_items if item.path.split("/")[-1].isdigit()
     )
 
     if not sessions:
@@ -121,24 +151,23 @@ def sync_dataset_card(repo_id: str) -> None:
 
     session_config_lines = []
     for s in sessions:
-        session_config_lines.extend([
-            f'  - config_name: "{s}"',
-            "    data_files:",
-            "      - split: train",
-            f'        path: "data/{s}/*.parquet"',
-        ])
+        session_config_lines.extend(
+            [
+                f'  - config_name: "{s}"',
+                "    data_files:",
+                "      - split: train",
+                f'        path: "data/{s}/*.parquet"',
+            ]
+        )
 
-    readme_content = DATASET_CARD_TEMPLATE.format(
-        session_configs="\n".join(session_config_lines)
-    )
+    readme_content = DATASET_CARD_TEMPLATE.format(session_configs="\n".join(session_config_lines))
     api.upload_file(
         path_or_fileobj=readme_content.encode("utf-8"),
         path_in_repo="README.md",
         repo_id=repo_id,
         repo_type="dataset",
         commit_message=(
-            f"Sync dataset card: {len(sessions)} sessions "
-            f"({sessions[0]}–{sessions[-1]})"
+            f"Sync dataset card: {len(sessions)} sessions ({sessions[0]}–{sessions[-1]})"
         ),
     )
     logger.info(f"Dataset card updated with {len(sessions)} session configs")

--- a/src/maine_bills/schema.py
+++ b/src/maine_bills/schema.py
@@ -135,6 +135,12 @@ class BillRecord:
 
     Merges filename-based metadata (always present) with content-based metadata
     (extracted from bill text, may be None/empty).
+
+    Sponsor enrichment fields (dataset v2) are additive and nullable: each is a
+    list aligned index-wise with ``sponsors`` (entry i describes sponsors[i]),
+    with None where no match was found. Records without enrichment default to
+    all-None entries, so v1-style construction remains valid. The original
+    ``sponsors`` strings are provenance and are never modified by enrichment.
     """
 
     # Filename-based metadata (always present)
@@ -155,10 +161,40 @@ class BillRecord:
     committee: str | None = None
     amended_code_refs: list[str] = field(default_factory=list)
 
+    # Sponsor enrichment (v2, additive; aligned index-wise with `sponsors`)
+    sponsor_ids: list[str | None] = field(default_factory=list)
+    sponsor_parties: list[str | None] = field(default_factory=list)
+    sponsor_districts: list[str | None] = field(default_factory=list)
+    sponsor_match_confidence: list[float | None] = field(default_factory=list)
+
     # Provenance
     source_url: str = ""
     source_filename: str = ""
     scraped_at: str = ""
+
+    ENRICHMENT_FIELDS = (
+        "sponsor_ids",
+        "sponsor_parties",
+        "sponsor_districts",
+        "sponsor_match_confidence",
+    )
+
+    def __post_init__(self):
+        """Normalize enrichment lists to stay aligned with `sponsors`.
+
+        Empty enrichment lists (the default, and the v1 case) are padded with
+        None to len(sponsors). Non-empty lists must already match len(sponsors).
+        """
+        for field_name in self.ENRICHMENT_FIELDS:
+            values = getattr(self, field_name)
+            if not values:
+                setattr(self, field_name, [None] * len(self.sponsors))
+            elif len(values) != len(self.sponsors):
+                raise ValueError(
+                    f"{field_name} has {len(values)} entries but there are "
+                    f"{len(self.sponsors)} sponsors; enrichment lists must "
+                    "align index-wise with sponsors"
+                )
 
     @classmethod
     def from_filename_and_bill_document(

--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -538,9 +538,13 @@ class TextExtractor:
         # Scanned-PDF session header lines (appear after line-number stripping)
         if re.match(r'^HOUSE OF REPRESENTATIVES\s*$', line_stripped, re.IGNORECASE):
             return True
-        if re.match(r'^\d+(?:ST|ND|RD|TH)\s+(?:MAINE\s+)?LEGISLATURE\s*$', line_stripped, re.IGNORECASE):
+        if re.match(
+            r'^\d+(?:ST|ND|RD|TH)\s+(?:MAINE\s+)?LEGISLATURE\s*$', line_stripped, re.IGNORECASE
+        ):
             return True
-        if re.match(r'^(?:FIRST|SECOND|THIRD)\s+(?:REGULAR|SPECIAL)\s+SESSION', line_stripped, re.IGNORECASE):
+        if re.match(
+            r'^(?:FIRST|SECOND|THIRD)\s+(?:REGULAR|SPECIAL)\s+SESSION', line_stripped, re.IGNORECASE
+        ):
             return True
 
         return False

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -69,3 +69,77 @@ def test_workers_custom():
     parser = build_parser()
     args = parser.parse_args(["--workers", "16"])
     assert args.workers == 16
+
+
+def test_enrich_flag_defaults_false():
+    parser = build_parser()
+    args = parser.parse_args([])
+    assert args.enrich is False
+
+
+def test_enrich_flag():
+    parser = build_parser()
+    args = parser.parse_args(["--enrich"])
+    assert args.enrich is True
+
+
+def test_enrich_noops_gracefully_when_matcher_unavailable(mocker, tmp_path):
+    """--enrich without the sponsor_matching module warns and completes normally."""
+    import pandas as pd
+
+    from maine_bills.cli import main
+
+    mock_scraper = mocker.patch("maine_bills.cli.BillScraper")
+    mock_scraper.return_value.scrape_session.return_value = pd.DataFrame(
+        [{"session": 132, "sponsors": ["Senator SMITH"], "text": "hello"}]
+    )
+    mocker.patch(
+        "sys.argv",
+        ["maine-bills", "--sessions", "132", "--enrich", "--local-dir", str(tmp_path)],
+    )
+    mock_load = mocker.patch("maine_bills.enrichment.load_matcher", return_value=None)
+    mock_enrich = mocker.patch("maine_bills.enrichment.enrich_dataframe")
+
+    assert main() == 0
+    mock_load.assert_called_once()
+    mock_enrich.assert_not_called()
+    assert (tmp_path / "132" / "train-00000-of-00001.parquet").exists()
+
+
+def test_enrich_applies_matcher_when_available(mocker, tmp_path):
+    """--enrich runs enrich_dataframe on each session when a matcher loads."""
+    import pandas as pd
+
+    from maine_bills.cli import main
+
+    df = pd.DataFrame([{"session": 132, "sponsors": ["Senator SMITH"], "text": "hello"}])
+    mock_scraper = mocker.patch("maine_bills.cli.BillScraper")
+    mock_scraper.return_value.scrape_session.return_value = df
+    mocker.patch(
+        "sys.argv",
+        ["maine-bills", "--sessions", "132", "--enrich", "--local-dir", str(tmp_path)],
+    )
+    matcher_fn = lambda sponsors: [None] * len(sponsors)  # noqa: E731
+    mocker.patch("maine_bills.enrichment.load_matcher", return_value=matcher_fn)
+    mock_enrich = mocker.patch("maine_bills.enrichment.enrich_dataframe", return_value=df)
+
+    assert main() == 0
+    mock_enrich.assert_called_once()
+    assert mock_enrich.call_args.args[1] is matcher_fn
+
+
+def test_no_enrich_never_touches_enrichment(mocker, tmp_path):
+    """Without --enrich, the enrichment module is never invoked."""
+    import pandas as pd
+
+    from maine_bills.cli import main
+
+    mock_scraper = mocker.patch("maine_bills.cli.BillScraper")
+    mock_scraper.return_value.scrape_session.return_value = pd.DataFrame(
+        [{"session": 132, "text": "hello"}]
+    )
+    mocker.patch("sys.argv", ["maine-bills", "--sessions", "132", "--local-dir", str(tmp_path)])
+    mock_load = mocker.patch("maine_bills.enrichment.load_matcher")
+
+    assert main() == 0
+    mock_load.assert_not_called()

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -1,0 +1,201 @@
+"""Tests for the sponsor enrichment integration point (schema v2)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from maine_bills.enrichment import apply_enrichment, enrich_dataframe, load_matcher
+from maine_bills.schema import BillRecord
+
+
+def make_record(sponsors):
+    return BillRecord(
+        session=132,
+        ld_number="0001",
+        document_type="bill",
+        amendment_code=None,
+        amendment_type=None,
+        chamber=None,
+        text="Bill text",
+        extraction_confidence=0.9,
+        sponsors=sponsors,
+    )
+
+
+def make_match(**overrides):
+    """Attribute-style match object as produced by the sponsor matcher."""
+    defaults = dict(
+        openstates_id="ocd-person/abc-123",
+        canonical_name="Jane Smith",
+        party="Democratic",
+        district="12",
+        confidence=1.0,
+        method="exact",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+# --- apply_enrichment ---
+
+
+class TestApplyEnrichment:
+    def test_applies_object_matches(self):
+        record = make_record(["Senator SMITH", "Representative JONES"])
+        matches = [
+            make_match(),
+            make_match(
+                openstates_id="ocd-person/def-456",
+                party="Republican",
+                district="45",
+                confidence=0.91,
+            ),
+        ]
+
+        apply_enrichment(record, matches)
+
+        assert record.sponsor_ids == ["ocd-person/abc-123", "ocd-person/def-456"]
+        assert record.sponsor_parties == ["Democratic", "Republican"]
+        assert record.sponsor_districts == ["12", "45"]
+        assert record.sponsor_match_confidence == [1.0, 0.91]
+
+    def test_applies_dict_matches(self):
+        record = make_record(["Senator SMITH"])
+        matches = [
+            {
+                "openstates_id": "ocd-person/abc-123",
+                "canonical_name": "Jane Smith",
+                "party": "Democratic",
+                "district": "12",
+                "confidence": 0.88,
+                "method": "fuzzy",
+            }
+        ]
+
+        apply_enrichment(record, matches)
+
+        assert record.sponsor_ids == ["ocd-person/abc-123"]
+        assert record.sponsor_parties == ["Democratic"]
+        assert record.sponsor_districts == ["12"]
+        assert record.sponsor_match_confidence == [0.88]
+
+    def test_unmatched_sponsors_stay_none(self):
+        record = make_record(["Senator SMITH", "Representative UNKNOWN"])
+
+        apply_enrichment(record, [make_match(), None])
+
+        assert record.sponsor_ids == ["ocd-person/abc-123", None]
+        assert record.sponsor_parties == ["Democratic", None]
+        assert record.sponsor_districts == ["12", None]
+        assert record.sponsor_match_confidence == [1.0, None]
+
+    def test_sponsors_strings_never_modified(self):
+        """Enrichment must not rewrite the verbatim sponsor names (provenance)."""
+        sponsors = ["Senator SMTIH"]  # deliberate typo, fuzzy-matched
+        record = make_record(list(sponsors))
+
+        apply_enrichment(record, [make_match(canonical_name="Jane Smith", method="fuzzy")])
+
+        assert record.sponsors == sponsors
+
+    def test_misaligned_matches_raise(self):
+        record = make_record(["Senator SMITH", "Representative JONES"])
+        with pytest.raises(ValueError, match="align index-wise"):
+            apply_enrichment(record, [make_match()])
+
+    def test_empty_sponsors_empty_matches(self):
+        record = make_record([])
+        apply_enrichment(record, [])
+        assert record.sponsor_ids == []
+        assert record.sponsor_match_confidence == []
+
+    def test_returns_same_record(self):
+        record = make_record(["Senator SMITH"])
+        assert apply_enrichment(record, [None]) is record
+
+
+# --- enrich_dataframe ---
+
+
+class TestEnrichDataframe:
+    def _make_df(self):
+        records = [
+            make_record(["Senator SMITH", "Representative UNKNOWN"]),
+            make_record([]),
+        ]
+        return pd.DataFrame([r.__dict__ for r in records])
+
+    def test_fills_enrichment_columns(self):
+        df = self._make_df()
+
+        def matcher_fn(sponsors):
+            return [make_match() if "SMITH" in name else None for name in sponsors]
+
+        result = enrich_dataframe(df, matcher_fn)
+
+        assert result.iloc[0]["sponsor_ids"] == ["ocd-person/abc-123", None]
+        assert result.iloc[0]["sponsor_parties"] == ["Democratic", None]
+        assert result.iloc[0]["sponsor_districts"] == ["12", None]
+        assert result.iloc[0]["sponsor_match_confidence"] == [1.0, None]
+        assert result.iloc[1]["sponsor_ids"] == []
+
+    def test_passes_session_when_matcher_accepts_it(self):
+        df = self._make_df()
+        seen_sessions = []
+
+        def matcher_fn(sponsors, session=None):
+            seen_sessions.append(session)
+            return [None] * len(sponsors)
+
+        enrich_dataframe(df, matcher_fn)
+        assert seen_sessions == [132, 132]
+
+    def test_sponsors_column_untouched(self):
+        df = self._make_df()
+        enrich_dataframe(df, lambda sponsors: [make_match()] * len(sponsors))
+        assert list(df.iloc[0]["sponsors"]) == ["Senator SMITH", "Representative UNKNOWN"]
+
+    def test_misaligned_matcher_output_raises(self):
+        df = self._make_df()
+        with pytest.raises(ValueError, match="Matcher returned"):
+            enrich_dataframe(df, lambda sponsors: [None])
+
+    def test_empty_dataframe_is_noop(self):
+        df = pd.DataFrame()
+        matcher_fn = MagicMock()
+        result = enrich_dataframe(df, matcher_fn)
+        assert result.empty
+        matcher_fn.assert_not_called()
+
+
+# --- load_matcher ---
+
+
+class TestLoadMatcher:
+    def test_returns_none_and_warns_when_module_missing(self):
+        """sponsor_matching is built on a parallel branch; absence must no-op."""
+        logger = MagicMock()
+        matcher_fn = load_matcher(logger)
+
+        # The module does not exist on this branch
+        assert matcher_fn is None
+        logger.warning.assert_called_once()
+        assert "sponsor_matching" in logger.warning.call_args.args[0]
+
+    def test_returns_match_function_when_module_present(self, mocker):
+        fake_module = MagicMock()
+        fake_module.match_sponsors = lambda sponsors: [None] * len(sponsors)
+        mocker.patch.dict("sys.modules", {"maine_bills.sponsor_matching": fake_module})
+
+        matcher_fn = load_matcher(MagicMock())
+        assert matcher_fn is fake_module.match_sponsors
+
+    def test_warns_when_module_lacks_match_function(self, mocker):
+        fake_module = MagicMock(spec=[])  # no match_sponsors attribute
+        mocker.patch.dict("sys.modules", {"maine_bills.sponsor_matching": fake_module})
+
+        logger = MagicMock()
+        assert load_matcher(logger) is None
+        logger.warning.assert_called_once()

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -199,3 +199,46 @@ class TestLoadMatcher:
         logger = MagicMock()
         assert load_matcher(logger) is None
         logger.warning.assert_called_once()
+
+
+class TestMatcherContractEdgeCases:
+    """Regression tests for review findings on falsy matches and introspection."""
+
+    def test_falsy_match_object_is_not_treated_as_unmatched(self):
+        """A match with a falsy __bool__ must still populate enrichment columns."""
+
+        class FalsyMatch:
+            openstates_id = "ocd-person/x1"
+            party = "Democratic"
+            district = "23"
+            confidence = 1.0
+
+            def __bool__(self):
+                return False
+
+        df = pd.DataFrame([{"session": 132, "sponsors": ["DAUGHTRY"]}])
+        out = enrich_dataframe(df, lambda sponsors: [FalsyMatch()])
+        assert out["sponsor_ids"][0] == ["ocd-person/x1"]
+        assert out["sponsor_parties"][0] == ["Democratic"]
+        assert out["sponsor_match_confidence"][0] == [1.0]
+
+    def test_empty_dict_match_is_not_treated_as_unmatched(self):
+        """An empty dict is falsy but present; its (absent) fields read as None."""
+        df = pd.DataFrame([{"session": 132, "sponsors": ["DAUGHTRY"]}])
+        out = enrich_dataframe(df, lambda sponsors: [{}])
+        assert out["sponsor_ids"][0] == [None]
+
+    def test_uninspectable_matcher_falls_back_instead_of_raising(self):
+        """inspect.signature() raising must not abort enrichment."""
+
+        class NoSignature:
+            def __call__(self, sponsors):
+                return [None] * len(sponsors)
+
+            @property
+            def __signature__(self):
+                raise ValueError("not introspectable")
+
+        df = pd.DataFrame([{"session": 132, "sponsors": ["DAUGHTRY"]}])
+        out = enrich_dataframe(df, NoSignature())
+        assert out["sponsor_ids"][0] == [None]

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 # --- publish_session ---
 
+
 def test_publish_session_writes_parquet_locally(tmp_path, mocker):
     from maine_bills.publish import publish_session
 
@@ -53,6 +54,7 @@ def test_publish_session_commit_message_includes_record_count(tmp_path, mocker):
 
 # --- sync_dataset_card ---
 
+
 def test_sync_dataset_card_uploads_readme(mocker):
     from maine_bills.publish import sync_dataset_card
 
@@ -91,6 +93,54 @@ def test_sync_dataset_card_readme_contains_session_configs(mocker):
     assert 'config_name: "131"' in readme
     assert 'config_name: "all"' in readme
     assert "data/131/*.parquet" in readme
+
+
+def _sync_card_and_get_readme(mocker):
+    """Run sync_dataset_card against a mocked HfApi and return the README text."""
+    from maine_bills.publish import sync_dataset_card
+
+    mock_api_instance = MagicMock()
+    mocker.patch("maine_bills.publish.HfApi", return_value=mock_api_instance)
+
+    item = MagicMock(spec=["path"])
+    item.path = "data/132"
+    mock_api_instance.list_repo_tree.return_value = [item]
+
+    sync_dataset_card("pem207/maine-bills")
+
+    readme_bytes = mock_api_instance.upload_file.call_args.kwargs["path_or_fileobj"]
+    return readme_bytes.decode("utf-8")
+
+
+def test_sync_dataset_card_documents_v2_enrichment_columns(mocker):
+    """Dataset card schema table includes all four v2 enrichment columns."""
+    readme = _sync_card_and_get_readme(mocker)
+
+    assert "`sponsor_ids`" in readme
+    assert "`sponsor_parties`" in readme
+    assert "`sponsor_districts`" in readme
+    assert "`sponsor_match_confidence`" in readme
+    # Original sponsors column stays documented as provenance
+    assert "`sponsors`" in readme
+    assert "provenance" in readme
+
+
+def test_sync_dataset_card_includes_methodology_section(mocker):
+    """Dataset card documents the two-pass matching methodology."""
+    readme = _sync_card_and_get_readme(mocker)
+
+    assert "## Sponsor enrichment methodology" in readme
+    assert "OpenStates" in readme
+    assert "rapidfuzz" in readme
+    assert "threshold" in readme
+    # Unmatched sponsors are left null
+    assert "null" in readme
+
+
+def test_sync_dataset_card_includes_version_note(mocker):
+    """Dataset card carries a v2 version note."""
+    readme = _sync_card_and_get_readme(mocker)
+    assert "v2" in readme
 
 
 def test_sync_dataset_card_skips_non_session_entries(mocker):

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -394,6 +394,131 @@ class TestBillRecord:
         datetime.fromisoformat(record.scraped_at)
 
 
+class TestSponsorEnrichmentFields:
+    """Test v2 sponsor enrichment fields on BillRecord."""
+
+    def _make_record(self, sponsors=None, **overrides):
+        kwargs = dict(
+            session=131,
+            ld_number="0001",
+            document_type="bill",
+            amendment_code=None,
+            amendment_type=None,
+            chamber=None,
+            text="Bill text",
+            extraction_confidence=0.9,
+            sponsors=sponsors if sponsors is not None else ["Senator Smith", "Rep. Jones"],
+        )
+        kwargs.update(overrides)
+        return BillRecord(**kwargs)
+
+    def test_defaults_are_none_padded_to_sponsors(self):
+        """V1-style construction leaves aligned all-None enrichment lists."""
+        record = self._make_record()
+        assert record.sponsor_ids == [None, None]
+        assert record.sponsor_parties == [None, None]
+        assert record.sponsor_districts == [None, None]
+        assert record.sponsor_match_confidence == [None, None]
+
+    def test_defaults_empty_when_no_sponsors(self):
+        """Records without sponsors get empty enrichment lists."""
+        record = self._make_record(sponsors=[])
+        assert record.sponsor_ids == []
+        assert record.sponsor_parties == []
+        assert record.sponsor_districts == []
+        assert record.sponsor_match_confidence == []
+
+    def test_explicit_enrichment_values_preserved(self):
+        """Explicitly provided enrichment lists are kept as-is."""
+        record = self._make_record(
+            sponsor_ids=["ocd-person/abc", None],
+            sponsor_parties=["Democratic", None],
+            sponsor_districts=["12", None],
+            sponsor_match_confidence=[1.0, None],
+        )
+        assert record.sponsor_ids == ["ocd-person/abc", None]
+        assert record.sponsor_parties == ["Democratic", None]
+        assert record.sponsor_districts == ["12", None]
+        assert record.sponsor_match_confidence == [1.0, None]
+
+    def test_aligned_list_invariant(self):
+        """Enrichment lists always have the same length as sponsors."""
+        for sponsors in ([], ["Senator A"], ["Senator A", "Rep. B", "Rep. C"]):
+            record = self._make_record(sponsors=sponsors)
+            for field_name in BillRecord.ENRICHMENT_FIELDS:
+                assert len(getattr(record, field_name)) == len(record.sponsors)
+
+    def test_misaligned_enrichment_raises(self):
+        """Non-empty enrichment lists of the wrong length are rejected."""
+        with pytest.raises(ValueError, match="align index-wise"):
+            self._make_record(sponsor_ids=["ocd-person/abc"])  # 1 id, 2 sponsors
+
+        with pytest.raises(ValueError, match="align index-wise"):
+            self._make_record(sponsor_match_confidence=[1.0, 0.9, 0.8])
+
+    def test_from_filename_and_bill_document_defaults(self):
+        """Factory-built records get aligned null enrichment (v1 compatible)."""
+        bill_doc = Mock()
+        bill_doc.body_text = "Text"
+        bill_doc.extraction_confidence = 0.9
+        bill_doc.title = None
+        bill_doc.sponsors = ["Senator Test", "Representative Other"]
+        bill_doc.committee = None
+        bill_doc.amended_code_refs = []
+
+        record = BillRecord.from_filename_and_bill_document(
+            "131-LD-0001", bill_doc, "http://example.com/"
+        )
+        assert record.sponsors == ["Senator Test", "Representative Other"]
+        assert record.sponsor_ids == [None, None]
+        assert record.sponsor_parties == [None, None]
+        assert record.sponsor_districts == [None, None]
+        assert record.sponsor_match_confidence == [None, None]
+
+    def test_parquet_round_trip_without_enrichment(self, tmp_path):
+        """Records without enrichment survive a DataFrame -> parquet round trip."""
+        import pandas as pd
+
+        record = self._make_record()
+        df = pd.DataFrame([record.__dict__])
+        path = tmp_path / "bills.parquet"
+        df.to_parquet(path, index=False)
+
+        loaded = pd.read_parquet(path)
+        row = loaded.iloc[0]
+        assert list(row["sponsors"]) == ["Senator Smith", "Rep. Jones"]
+        assert len(row["sponsor_ids"]) == 2
+        assert all(pd.isna(v) for v in row["sponsor_ids"])
+        assert len(row["sponsor_match_confidence"]) == 2
+        assert all(pd.isna(v) for v in row["sponsor_match_confidence"])
+
+    def test_parquet_round_trip_with_enrichment(self, tmp_path):
+        """Enriched records survive a DataFrame -> parquet round trip."""
+        import pandas as pd
+
+        record = self._make_record(
+            sponsor_ids=["ocd-person/abc", None],
+            sponsor_parties=["Democratic", None],
+            sponsor_districts=["12", None],
+            sponsor_match_confidence=[0.97, None],
+        )
+        df = pd.DataFrame([record.__dict__])
+        path = tmp_path / "bills.parquet"
+        df.to_parquet(path, index=False)
+
+        loaded = pd.read_parquet(path)
+        row = loaded.iloc[0]
+        # Original sponsors untouched (provenance)
+        assert list(row["sponsors"]) == ["Senator Smith", "Rep. Jones"]
+        assert row["sponsor_ids"][0] == "ocd-person/abc"
+        assert pd.isna(row["sponsor_ids"][1])
+        assert row["sponsor_parties"][0] == "Democratic"
+        assert row["sponsor_districts"][0] == "12"
+        confidences = row["sponsor_match_confidence"]
+        assert confidences[0] == pytest.approx(0.97)
+        assert pd.isna(confidences[1])
+
+
 class TestAmendmentConstants:
     """Test amendment type and chamber mapping constants."""
 


### PR DESCRIPTION
## What

The v2 dataset schema: `BillRecord` gains four **additive, nullable** fields, index-aligned with the existing `sponsors` list — `sponsor_ids`, `sponsor_parties`, `sponsor_districts`, `sponsor_match_confidence`. Original extracted sponsor strings are never modified (provenance). `__post_init__` pads empty lists to `[None] * len(sponsors)` so v1-style construction stays valid, and rejects misaligned non-empty lists with `ValueError`.

Supporting pieces:
- **`enrichment.py` (new)** — matcher-agnostic integration point: `apply_enrichment(record, matches)` and `enrich_dataframe(df, matcher_fn)`; the matcher module (parallel branch `claude/sprint-openstates-matching`) is resolved lazily by `load_matcher()` and is not imported directly, so this PR stands alone.
- **`cli.py`** — optional `--enrich` flag that warns and no-ops if the matcher module is absent.
- **`publish.py`** — dataset card documents the four new columns, alignment semantics (nulls read back as NaN from parquet — consumers should use null-aware checks), a "Sponsor enrichment methodology" section, and a v2 version note.
- Includes the same 2-line `text_extractor.py` lint fix already cherry-picked onto the CI branch (identical commit; merges cleanly in either order).

**Tests: 182 passing (+31), 93% coverage; `schema.py` and `enrichment.py` at 100%. Ruff clean.**

## Risk summary

This is the sprint's key irreversible decision: the parquet column layout for v2. Everything is additive and nullable, so v1 consumers and unenriched records remain valid, and the original extracted strings are untouched — the main thing to sanity-check in review is the field naming and the aligned-list representation (vs. e.g. a nested struct column). One known coupling: `load_matcher` expects the matching branch to expose `match_sponsors(sponsors, session=...)`; if the matcher lands with a different name, it's a one-line lookup change, and the `--enrich` flag degrades to a warning rather than an error in the meantime.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WicqsC1r64bRg1pbAqFsTV)_