### PR TITLE
[Tier-2] feat: Gate A sample-feedback review UI

### DIFF
--- a/tools/review_ui/README.md
+++ b/tools/review_ui/README.md
@@ -6,12 +6,15 @@ network — open the file in a browser.
 
 ## matching_review.html (Gate A)
 
-1. Run the `data-run.yml` workflow with task `run-matching`; download the
-   report artifact.
+1. Run the `data-run.yml` workflow with task `run-matching` (sessions e.g.
+   `121 122 ... 132`); download the report artifact. If the workflow version
+   you're on doesn't pass source/output flags itself, set `extra_args` to
+   `--parquet-source hf://datasets/pem207/maine-bills --output report`.
 2. Open `matching_review.html`, drop `matching_report.json` on it.
 3. Review: per-session match rates vs the 95% gate, the random fuzzy-match
    sample (✓/✗/⚑, keys y/n/f), and the unmatched/ambiguous name lists.
 4. Export `matching_verdicts.json` and attach it to the gate PR/issue —
    agents consume it to tune thresholds and add regression tests.
 
-Verdicts persist in localStorage per report, so an interrupted review resumes.
+Verdicts persist in localStorage for the most recently loaded report, so an
+interrupted review resumes; loading a different report starts fresh.

--- a/tools/review_ui/README.md
+++ b/tools/review_ui/README.md
@@ -1,0 +1,17 @@
+# Sample-feedback review UIs
+
+Disposable, self-contained HTML pages for human data-quality review during
+gates (see docs/GOVERNANCE.md "Human review tooling"). No build step, no
+network — open the file in a browser.
+
+## matching_review.html (Gate A)
+
+1. Run the `data-run.yml` workflow with task `run-matching`; download the
+   report artifact.
+2. Open `matching_review.html`, drop `matching_report.json` on it.
+3. Review: per-session match rates vs the 95% gate, the random fuzzy-match
+   sample (✓/✗/⚑, keys y/n/f), and the unmatched/ambiguous name lists.
+4. Export `matching_verdicts.json` and attach it to the gate PR/issue —
+   agents consume it to tune thresholds and add regression tests.
+
+Verdicts persist in localStorage per report, so an interrupted review resumes.

--- a/tools/review_ui/matching_review.html
+++ b/tools/review_ui/matching_review.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sponsor Matching Review</title>
+<style>
+  :root { --ok:#1a7f37; --bad:#cf222e; --flag:#9a6700; --muted:#57606a; --border:#d0d7de; --bg:#f6f8fa; }
+  * { box-sizing:border-box; }
+  body { font:14px/1.5 -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; margin:0; color:#1f2328; }
+  header { padding:12px 20px; border-bottom:1px solid var(--border); display:flex; gap:16px; align-items:center; flex-wrap:wrap; }
+  h1 { font-size:16px; margin:0; }
+  main { padding:16px 20px; max-width:1000px; }
+  .drop { border:2px dashed var(--border); border-radius:8px; padding:32px; text-align:center; color:var(--muted); margin:24px 0; }
+  .drop.hover { background:var(--bg); }
+  table { border-collapse:collapse; width:100%; margin:8px 0 20px; }
+  th, td { border:1px solid var(--border); padding:4px 10px; text-align:right; }
+  th:first-child, td:first-child { text-align:left; }
+  .bar { display:inline-block; height:8px; background:var(--ok); border-radius:4px; vertical-align:middle; }
+  .warn { color:var(--bad); font-weight:600; }
+  .tabs { display:flex; gap:4px; margin:16px 0 8px; border-bottom:1px solid var(--border); }
+  .tabs button { border:1px solid var(--border); border-bottom:none; background:var(--bg); padding:6px 14px; border-radius:6px 6px 0 0; cursor:pointer; font-size:13px; }
+  .tabs button.active { background:#fff; font-weight:600; }
+  .card { border:1px solid var(--border); border-radius:8px; padding:12px 16px; margin:10px 0; display:flex; gap:16px; align-items:center; flex-wrap:wrap; }
+  .card.decided-correct { border-left:4px solid var(--ok); }
+  .card.decided-incorrect { border-left:4px solid var(--bad); }
+  .card.decided-flag { border-left:4px solid var(--flag); }
+  .pair { flex:1; min-width:260px; }
+  .pair .from { font-weight:600; }
+  .pair .to { color:var(--muted); }
+  .conf { font-variant-numeric:tabular-nums; color:var(--muted); min-width:70px; }
+  .meta { color:var(--muted); font-size:12px; min-width:160px; }
+  .btns button { border:1px solid var(--border); background:#fff; border-radius:6px; padding:4px 10px; cursor:pointer; margin-left:4px; font-size:13px; }
+  .btns button.sel-correct { background:var(--ok); color:#fff; border-color:var(--ok); }
+  .btns button.sel-incorrect { background:var(--bad); color:#fff; border-color:var(--bad); }
+  .btns button.sel-flag { background:var(--flag); color:#fff; border-color:var(--flag); }
+  .note { width:100%; border:1px solid var(--border); border-radius:6px; padding:4px 8px; font-size:13px; display:none; }
+  .note.show { display:block; }
+  .progress { color:var(--muted); font-size:13px; }
+  .primary { background:#1f883d; color:#fff; border:none; border-radius:6px; padding:6px 14px; cursor:pointer; font-size:13px; }
+  .hint { color:var(--muted); font-size:12px; }
+  #filecheck { display:none; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Sponsor → OpenStates Matching Review</h1>
+  <span class="progress" id="progress"></span>
+  <span style="flex:1"></span>
+  <span class="hint">keys: <b>y</b> correct · <b>n</b> incorrect · <b>f</b> flag</span>
+  <button class="primary" id="export" hidden>Export verdicts JSON</button>
+</header>
+<main>
+  <div class="drop" id="drop">
+    Drop <code>matching_report.json</code> here or
+    <label style="color:#0969da;cursor:pointer"><u>choose file</u><input type="file" id="filecheck" accept=".json"></label>
+    — the artifact from the <code>data-run.yml → run-matching</code> workflow.
+  </div>
+  <div id="app" hidden>
+    <h2 style="font-size:15px">Per-session match rates <span class="hint">(Gate A target: ≥95% matched = exact + fuzzy)</span></h2>
+    <div id="sessions"></div>
+    <div class="tabs" id="tabs"></div>
+    <div id="cards"></div>
+  </div>
+</main>
+<script>
+"use strict";
+let report = null, verdicts = {}, activeTab = "fuzzy", focusIdx = 0;
+const STORAGE_KEY = "matching-review-verdicts";
+
+const drop = document.getElementById("drop");
+drop.addEventListener("dragover", e => { e.preventDefault(); drop.classList.add("hover"); });
+drop.addEventListener("dragleave", () => drop.classList.remove("hover"));
+drop.addEventListener("drop", e => { e.preventDefault(); drop.classList.remove("hover"); loadFile(e.dataTransfer.files[0]); });
+document.getElementById("filecheck").addEventListener("change", e => loadFile(e.target.files[0]));
+
+function loadFile(file) {
+  if (!file) return;
+  file.text().then(t => {
+    report = JSON.parse(t);
+    verdicts = restore();
+    drop.hidden = true;
+    document.getElementById("app").hidden = false;
+    document.getElementById("export").hidden = false;
+    render();
+  }).catch(err => alert("Could not parse report JSON: " + err));
+}
+
+function restore() {
+  try {
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
+    return saved.generated_at === report.generated_at ? saved.verdicts : {};
+  } catch { return {}; }
+}
+function persist() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({ generated_at: report.generated_at, verdicts }));
+}
+
+function keyOf(item, type) {
+  return type + "|" + item.session + "|" + (item.sponsor || item.name) + "|" + (item.openstates_id || "");
+}
+
+function renderSessions() {
+  const rows = report.sessions.map(s => {
+    const matched = (s.rates.exact || 0) + (s.rates.fuzzy || 0);
+    const pct = (matched * 100).toFixed(1);
+    const cls = matched >= 0.95 ? "" : "warn";
+    return `<tr><td>${s.session}</td><td>${s.bills}</td><td>${s.sponsor_mentions}</td>
+      <td>${(s.rates.exact*100).toFixed(1)}%</td><td>${(s.rates.fuzzy*100).toFixed(1)}%</td>
+      <td>${s.counts.ambiguous}</td><td>${s.counts.unmatched}</td>
+      <td class="${cls}">${pct}% <span class="bar" style="width:${Math.round(matched*60)}px"></span></td></tr>`;
+  }).join("");
+  document.getElementById("sessions").innerHTML =
+    `<table><tr><th>Session</th><th>Bills</th><th>Mentions</th><th>Exact</th><th>Fuzzy</th>
+     <th>Ambig.</th><th>Unmatched</th><th>Matched</th></tr>${rows}</table>`;
+}
+
+function tabItems() {
+  if (activeTab === "fuzzy") return report.fuzzy_sample.map(m => ({ ...m, _type: "fuzzy" }));
+  const field = activeTab; // "unmatched" | "ambiguous"
+  const out = [];
+  for (const s of report.sessions)
+    for (const n of s[field]) out.push({ session: s.session, name: n.name, bill_count: n.bill_count, _type: field });
+  return out.sort((a, b) => b.bill_count - a.bill_count);
+}
+
+function renderTabs() {
+  const counts = {
+    fuzzy: report.fuzzy_sample.length,
+    unmatched: report.sessions.reduce((n, s) => n + s.unmatched.length, 0),
+    ambiguous: report.sessions.reduce((n, s) => n + s.ambiguous.length, 0),
+  };
+  document.getElementById("tabs").innerHTML = [
+    ["fuzzy", `Fuzzy sample (${counts.fuzzy})`],
+    ["unmatched", `Unmatched names (${counts.unmatched})`],
+    ["ambiguous", `Ambiguous names (${counts.ambiguous})`],
+  ].map(([id, label]) =>
+    `<button class="${id === activeTab ? "active" : ""}" onclick="switchTab('${id}')">${label}</button>`).join("");
+}
+
+function switchTab(id) { activeTab = id; focusIdx = 0; render(); }
+
+function renderCards() {
+  const items = tabItems();
+  document.getElementById("cards").innerHTML = items.map((item, i) => {
+    const k = keyOf(item, item._type);
+    const v = verdicts[k];
+    const decided = v ? " decided-" + v.verdict : "";
+    const body = item._type === "fuzzy"
+      ? `<div class="pair"><span class="from">${item.sponsor}</span> →
+           <span class="to">${item.canonical_name}</span><br>
+           <span class="hint">${item.openstates_id}</span></div>
+         <span class="conf">${(item.confidence * 100).toFixed(0)}%</span>
+         <span class="meta">s${item.session} · ${item.bill_id}</span>`
+      : `<div class="pair"><span class="from">${item.name}</span></div>
+         <span class="meta">s${item.session} · ${item.bill_count} bill(s)</span>`;
+    const btn = (verdict, label) =>
+      `<button class="${v && v.verdict === verdict ? "sel-" + verdict : ""}"
+        onclick="decide(${i},'${verdict}')">${label}</button>`;
+    return `<div class="card${decided}" id="card-${i}" tabindex="0">${body}
+      <span class="btns">${btn("correct", "✓")}${btn("incorrect", "✗")}${btn("flag", "⚑")}</span>
+      <input class="note ${v && v.note ? "show" : ""}" placeholder="note (optional)"
+        value="${v && v.note ? v.note.replace(/"/g, "&quot;") : ""}"
+        onchange="noteChange(${i}, this.value)"></div>`;
+  }).join("") || "<p class='hint'>Nothing in this bucket.</p>";
+  updateProgress(items);
+}
+
+function decide(i, verdict) {
+  const item = tabItems()[i];
+  const k = keyOf(item, item._type);
+  verdicts[k] = { ...(verdicts[k] || {}), item: strip(item), verdict };
+  if (verdict === "flag") setTimeout(() => {
+    const note = document.querySelector(`#card-${i} .note`);
+    note.classList.add("show"); note.focus();
+  });
+  focusIdx = i + 1;
+  persist(); render();
+  const next = document.getElementById("card-" + focusIdx);
+  if (next) next.scrollIntoView({ block: "center" });
+}
+function noteChange(i, value) {
+  const k = keyOf(tabItems()[i], tabItems()[i]._type);
+  if (verdicts[k]) { verdicts[k].note = value; persist(); }
+}
+function strip(item) { const { _type, ...rest } = item; return { type: _type, ...rest }; }
+
+function updateProgress(items) {
+  const done = items.filter(it => verdicts[keyOf(it, it._type)]).length;
+  document.getElementById("progress").textContent = `${done}/${items.length} reviewed in this tab`;
+}
+
+document.addEventListener("keydown", e => {
+  if (!report || e.target.tagName === "INPUT") return;
+  const map = { y: "correct", n: "incorrect", f: "flag" };
+  if (map[e.key]) { e.preventDefault(); decide(focusIdx, map[e.key]); }
+});
+
+document.getElementById("export").addEventListener("click", () => {
+  const payload = {
+    reviewed_at: new Date().toISOString(),
+    report_generated_at: report.generated_at,
+    verdicts: Object.values(verdicts),
+  };
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = "matching_verdicts.json";
+  a.click();
+});
+
+function render() { renderSessions(); renderTabs(); renderCards(); }
+</script>
+</body>
+</html>

--- a/tools/review_ui/matching_review.html
+++ b/tools/review_ui/matching_review.html
@@ -94,7 +94,13 @@ function restore() {
   } catch { return {}; }
 }
 function persist() {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify({ generated_at: report.generated_at, verdicts }));
+  // Storage can be disabled, full, or blocked under file:// — a failed save
+  // must not stop the review; verdicts stay in memory and still export.
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ generated_at: report.generated_at, verdicts }));
+  } catch (err) {
+    if (!persist.warned) { persist.warned = true; console.warn("Progress not saved locally:", err); }
+  }
 }
 
 // Intentionally omits bill_id for fuzzy entries: the sponsor-string → legislator
@@ -163,11 +169,13 @@ function renderCards() {
          <span class="meta">s${esc(item.session)} · ${esc(item.bill_id)}</span>`
       : `<div class="pair"><span class="from">${esc(item.name)}</span></div>
          <span class="meta">s${esc(item.session)} · ${esc(item.bill_count)} bill(s)</span>`;
+    const LABELS = { correct: "Mark correct", incorrect: "Mark incorrect", flag: "Flag for follow-up" };
     const btn = (verdict, label) =>
       `<button class="${v && v.verdict === verdict ? "sel-" + verdict : ""}"
+        aria-label="${LABELS[verdict]}" title="${LABELS[verdict]}"
         onclick="event.stopPropagation();decide(${i},'${verdict}')">${label}</button>`;
     return `<div class="card${decided}${focused}" id="card-${i}" tabindex="0"
-      onclick="setFocus(${i})">${body}
+      onclick="setFocus(${i})" onfocus="setFocus(${i})">${body}
       <span class="btns">${btn("correct", "✓")}${btn("incorrect", "✗")}${btn("flag", "⚑")}</span>
       <input class="note ${v && v.note ? "show" : ""}" placeholder="note (optional)"
         value="${v && v.note ? esc(v.note) : ""}"
@@ -193,6 +201,7 @@ function decide(i, verdict) {
   verdicts[k] = { ...(verdicts[k] || {}), item: strip(item), verdict };
   if (verdict === "flag") setTimeout(() => {
     const note = document.querySelector(`#card-${i} .note`);
+    if (!note) return; // tab switched or list re-rendered before this ran
     note.classList.add("show"); note.focus();
   });
   focusIdx = i + 1;
@@ -226,9 +235,11 @@ document.getElementById("export").addEventListener("click", () => {
   };
   const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
   const a = document.createElement("a");
-  a.href = URL.createObjectURL(blob);
+  const url = URL.createObjectURL(blob);
+  a.href = url;
   a.download = "matching_verdicts.json";
   a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 });
 
 function render() { renderSessions(); renderTabs(); renderCards(); }

--- a/tools/review_ui/matching_review.html
+++ b/tools/review_ui/matching_review.html
@@ -25,6 +25,7 @@
   .card.decided-correct { border-left:4px solid var(--ok); }
   .card.decided-incorrect { border-left:4px solid var(--bad); }
   .card.decided-flag { border-left:4px solid var(--flag); }
+  .card.focused { outline:2px solid #0969da; outline-offset:1px; }
   .pair { flex:1; min-width:260px; }
   .pair .from { font-weight:600; }
   .pair .to { color:var(--muted); }
@@ -96,8 +97,15 @@ function persist() {
   localStorage.setItem(STORAGE_KEY, JSON.stringify({ generated_at: report.generated_at, verdicts }));
 }
 
+// Intentionally omits bill_id for fuzzy entries: the sponsor-string → legislator
+// pair is the semantic unit under review, so one verdict covers all its bills.
 function keyOf(item, type) {
   return type + "|" + item.session + "|" + (item.sponsor || item.name) + "|" + (item.openstates_id || "");
+}
+
+function esc(value) {
+  return String(value ?? "").replace(/[&<>"']/g, c =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 }
 
 function renderSessions() {
@@ -146,28 +154,41 @@ function renderCards() {
     const k = keyOf(item, item._type);
     const v = verdicts[k];
     const decided = v ? " decided-" + v.verdict : "";
+    const focused = i === focusIdx ? " focused" : "";
     const body = item._type === "fuzzy"
-      ? `<div class="pair"><span class="from">${item.sponsor}</span> →
-           <span class="to">${item.canonical_name}</span><br>
-           <span class="hint">${item.openstates_id}</span></div>
+      ? `<div class="pair"><span class="from">${esc(item.sponsor)}</span> →
+           <span class="to">${esc(item.canonical_name)}</span><br>
+           <span class="hint">${esc(item.openstates_id)}</span></div>
          <span class="conf">${(item.confidence * 100).toFixed(0)}%</span>
-         <span class="meta">s${item.session} · ${item.bill_id}</span>`
-      : `<div class="pair"><span class="from">${item.name}</span></div>
-         <span class="meta">s${item.session} · ${item.bill_count} bill(s)</span>`;
+         <span class="meta">s${esc(item.session)} · ${esc(item.bill_id)}</span>`
+      : `<div class="pair"><span class="from">${esc(item.name)}</span></div>
+         <span class="meta">s${esc(item.session)} · ${esc(item.bill_count)} bill(s)</span>`;
     const btn = (verdict, label) =>
       `<button class="${v && v.verdict === verdict ? "sel-" + verdict : ""}"
-        onclick="decide(${i},'${verdict}')">${label}</button>`;
-    return `<div class="card${decided}" id="card-${i}" tabindex="0">${body}
+        onclick="event.stopPropagation();decide(${i},'${verdict}')">${label}</button>`;
+    return `<div class="card${decided}${focused}" id="card-${i}" tabindex="0"
+      onclick="setFocus(${i})">${body}
       <span class="btns">${btn("correct", "✓")}${btn("incorrect", "✗")}${btn("flag", "⚑")}</span>
       <input class="note ${v && v.note ? "show" : ""}" placeholder="note (optional)"
-        value="${v && v.note ? v.note.replace(/"/g, "&quot;") : ""}"
+        value="${v && v.note ? esc(v.note) : ""}"
+        onclick="event.stopPropagation()"
         onchange="noteChange(${i}, this.value)"></div>`;
   }).join("") || "<p class='hint'>Nothing in this bucket.</p>";
   updateProgress(items);
 }
 
+function setFocus(i) {
+  if (i === focusIdx) return;
+  const prev = document.getElementById("card-" + focusIdx);
+  if (prev) prev.classList.remove("focused");
+  focusIdx = i;
+  const cur = document.getElementById("card-" + focusIdx);
+  if (cur) cur.classList.add("focused");
+}
+
 function decide(i, verdict) {
   const item = tabItems()[i];
+  if (!item) return; // past the last card, or empty tab
   const k = keyOf(item, item._type);
   verdicts[k] = { ...(verdicts[k] || {}), item: strip(item), verdict };
   if (verdict === "flag") setTimeout(() => {
@@ -192,6 +213,7 @@ function updateProgress(items) {
 
 document.addEventListener("keydown", e => {
   if (!report || e.target.tagName === "INPUT") return;
+  if (e.ctrlKey || e.metaKey || e.altKey) return; // never shadow Ctrl/Cmd+F etc.
   const map = { y: "correct", n: "incorrect", f: "flag" };
   if (map[e.key]) { e.preventDefault(); decide(focusIdx, map[e.key]); }
 });


### PR DESCRIPTION
## What

The sample-feedback review UI promised in the sprint plan and GOVERNANCE.md, pre-built so Gate A review can start the moment the first matching report exists. A single self-contained HTML page (`tools/review_ui/matching_review.html`, no build step, no network access) that loads the `matching_report.json` artifact from the `data-run.yml → run-matching` workflow and provides:

- Per-session match-rate table with the 95% Gate A threshold highlighted (below-gate sessions flagged red).
- **Targeted sample**: the seeded random fuzzy-match cards (extracted string → matched legislator, confidence, source bill) with ✓/✗/⚑ verdicts and `y`/`n`/`f` keyboard shortcuts, plus unmatched and ambiguous name lists sorted by bill impact.
- **Verdict export**: `matching_verdicts.json` download for agent consumption (threshold tuning, regression tests); progress persists in localStorage so an interrupted review resumes.

Smoke-tested with Playwright/Chromium against a mock report: file load, session table render, click + keyboard verdicts, tab switching, gate-threshold flagging, and export round-trip all verified with zero console errors.

## Tier decision

Tier-2: static tooling under `tools/`, no schema, publish, CI, dependency, or secret surface. Cannot merge until #6 lands (needs the `test`/`lint` checks to exist) and an independent agent review approves per governance — or human review, whichever comes first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WicqsC1r64bRg1pbAqFsTV)_