### PR TITLE
[Tier-2] fix: align matching report table header with its data columns

### DIFF
--- a/scripts/run_matching_report.py
+++ b/scripts/run_matching_report.py
@@ -55,6 +55,16 @@ logger = logging.getLogger("run_matching_report")
 METHODS = (METHOD_EXACT, METHOD_OCR, METHOD_FUZZY, METHOD_AMBIGUOUS, METHOD_UNMATCHED)
 FUZZY_SAMPLE_SIZE = 30
 
+# Column headings for the per-session table, keyed by method so adding a method
+# cannot silently shift the columns out of alignment with the data rows.
+_METHOD_HEADINGS = {
+    METHOD_EXACT: "Exact",
+    METHOD_OCR: "OCR",
+    METHOD_FUZZY: "Fuzzy",
+    METHOD_AMBIGUOUS: "Ambiguous",
+    METHOD_UNMATCHED: "Unmatched",
+}
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Sponsor -> OpenStates matching report")
@@ -235,8 +245,9 @@ def render_markdown(report: dict) -> str:
         "",
         "## Per-session match rates",
         "",
-        "| Session | Bills | Mentions | Exact | Fuzzy | Ambiguous | Unmatched |",
-        "|---------|-------|----------|-------|-------|-----------|-----------|",
+        # Derived from METHODS so a new match method can't silently shift columns
+        "| Session | Bills | Mentions | " + " | ".join(_METHOD_HEADINGS[m] for m in METHODS) + " |",
+        "|---------|-------|----------|" + "|".join(["-------"] * len(METHODS)) + "|",
     ]
     for stats in report["sessions"]:
         rates = stats["rates"]

--- a/tests/unit/test_matching_report.py
+++ b/tests/unit/test_matching_report.py
@@ -274,3 +274,20 @@ def test_chambers_null_column_falls_back_to_text(report_mod):
         "text": "Presented by Senator LIBBY of Androscoggin.\nBe it enacted",
     }
     assert report_mod.chambers_for_row(row, ["LIBBY"]) == ["Senate"]
+
+
+def test_markdown_header_matches_data_columns(report_mod):
+    """Regression: adding the ocr method shifted every column after Exact.
+
+    The header was hardcoded with four method columns while rows emitted one
+    per METHODS entry, so published reports mislabelled unmatched as fuzzy.
+    """
+    report = report_mod.build_report(
+        [report_mod.analyze_session(_bills_df(), SponsorMatcher(ROSTER), 132)], seed=1
+    )
+    lines = report_mod.render_markdown(report).splitlines()
+    header = next(line for line in lines if line.startswith("| Session"))
+    data = next(line for line in lines if line.startswith("| 132 "))
+
+    assert header.count("|") == data.count("|")
+    assert "OCR" in header


### PR DESCRIPTION
## The bug

When I added the `ocr` method, `METHODS` grew to five entries and the data rows followed, but the per-session table header was hardcoded with four method columns. Every column after **Exact** shifted right by one.

The consequence is that the report I've been reporting from was mislabelled. Session 121 reads as `0.8% fuzzy / 1.9% ambiguous / 83.7% unmatched` under the printed headings, but the true column order is `exact | ocr | fuzzy | ambiguous | unmatched` — so it's **13.6% exact and 83.7% unmatched**.

## The fix

Headings are keyed by method (`_METHOD_HEADINGS`) and both the header and separator rows are generated from `METHODS`, so adding a method can't silently shift columns again. Regression test asserts the header and data rows have equal cell counts and that the new column is labelled.

284 tests pass, ruff clean. Tier-2: `scripts/` only, no schema, publish, CI, secret, or dependency surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WicqsC1r64bRg1pbAqFsTV)_