### PR TITLE
[Tier-1] feat: enrich-in-place publishing path for v2

### DIFF
--- a/.github/workflows/enrich-publish.yml
+++ b/.github/workflows/enrich-publish.yml
@@ -1,0 +1,98 @@
+# Enrich the published dataset with sponsor matches and publish v2.
+#
+# Enrichment reads the parquet already on HuggingFace and fills the v2 sponsor
+# columns; it does not re-scrape. A full re-scrape of sessions 121-132 is about
+# 43,000 PDF downloads and cannot finish in one job, and enrichment needs none
+# of it — `sponsors` is published, and chamber hints come from the published
+# `text`.
+#
+# Publishing is gated by the `huggingface-publish` environment (required
+# reviewer), so the enriched parquet can be downloaded and inspected before
+# anything reaches the Hub.
+name: Enrich and Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      sessions:
+        description: "Space-separated sessions to enrich"
+        required: false
+        default: "121 122 123 124 125 126 127 128 129 130 131 132"
+      repo_id:
+        description: "HuggingFace dataset repo"
+        required: false
+        default: "pem207/maine-bills"
+
+permissions:
+  contents: read
+
+jobs:
+  enrich:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Enrich published sessions
+        run: |
+          uv run python scripts/enrich_published.py \
+            --sessions ${{ inputs.sessions }} \
+            --parquet-source hf://datasets/${{ inputs.repo_id }} \
+            --output data
+
+      - name: Write job summary
+        run: |
+          echo "## Sponsor enrichment" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Session | Mentions | Matched | Rate |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---------|----------|---------|------|" >> "$GITHUB_STEP_SUMMARY"
+          uv run python -c "
+          import json, pathlib
+          for s in json.loads(pathlib.Path('data/enrichment_summary.json').read_text()):
+              print(f\"| {s['session']} | {s['mentions']} | {s['matched']} | {s['rate']:.1%} |\")
+          " >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload enriched parquet
+        uses: actions/upload-artifact@v4
+        with:
+          name: enriched-parquet
+          path: data/
+          if-no-files-found: error
+          retention-days: 90
+
+  # Human gate: waits for a required reviewer on the `huggingface-publish`
+  # environment, then publishes exactly the artifact reviewed above.
+  publish:
+    needs: enrich
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: huggingface-publish
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Download enriched parquet
+        uses: actions/download-artifact@v4
+        with:
+          name: enriched-parquet
+          path: data/
+
+      - name: Publish to HuggingFace
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          uv run python scripts/publish_from_artifact.py \
+            --data-dir data --repo-id ${{ inputs.repo_id }}

--- a/.github/workflows/enrich-publish.yml
+++ b/.github/workflows/enrich-publish.yml
@@ -40,11 +40,22 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      # Dispatch inputs reach the shell through env, never via ${{ }}
+      # interpolation into the script body, so metacharacters cannot become
+      # part of the command. SESSIONS is deliberately unquoted on use (it
+      # expands to several arguments) and is validated to digits/spaces first.
       - name: Enrich published sessions
+        env:
+          SESSIONS: ${{ inputs.sessions }}
+          REPO_ID: ${{ inputs.repo_id }}
         run: |
+          case "$SESSIONS" in
+            "" | *[!0-9\ ]*)
+              echo "::error::sessions must be space-separated numbers"; exit 1 ;;
+          esac
           uv run python scripts/enrich_published.py \
-            --sessions ${{ inputs.sessions }} \
-            --parquet-source hf://datasets/${{ inputs.repo_id }} \
+            --sessions $SESSIONS \
+            --parquet-source "hf://datasets/$REPO_ID" \
             --output data
 
       - name: Write job summary
@@ -93,6 +104,7 @@ jobs:
       - name: Publish to HuggingFace
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          REPO_ID: ${{ inputs.repo_id }}
         run: |
           uv run python scripts/publish_from_artifact.py \
-            --data-dir data --repo-id ${{ inputs.repo_id }}
+            --data-dir data --repo-id "$REPO_ID"

--- a/scripts/enrich_published.py
+++ b/scripts/enrich_published.py
@@ -1,0 +1,113 @@
+"""Enrich the published dataset with sponsor matches, in place.
+
+Reads each session's parquet from HuggingFace (or a local dir), fills the v2
+sponsor enrichment columns, and writes the result to a local directory for the
+gated publish job to upload.
+
+Enrichment needs no PDFs: `sponsors` is already published, and chamber hints
+are derived from the published `text`, which retains the "Presented by Senator
+X of Y" block. A full re-scrape of sessions 121-132 would mean ~43,000 PDF
+downloads; this runs in minutes against the same data.
+
+Two caveats, documented in the dataset card:
+
+- `sponsors` was deduplicated by name when v1 was scraped, so a bill sponsored
+  by two legislators sharing a surname in different chambers has one entry and
+  takes that surname's first-mentioned chamber. Full fidelity arrives with the
+  next scrape (see schema.py / text_extractor.py).
+- Sessions differ widely in match rate; rates are reported per session so the
+  card can state them honestly rather than averaging them away.
+
+Usage:
+    uv run python scripts/enrich_published.py \\
+        --sessions 121 122 ... 132 \\
+        --parquet-source hf://datasets/pem207/maine-bills \\
+        --output data
+"""
+
+import argparse
+import importlib.util
+import json
+import logging
+import sys
+from pathlib import Path
+
+from maine_bills.enrichment import apply_enrichment  # noqa: F401  (contract reference)
+from maine_bills.openstates import get_roster
+from maine_bills.sponsor_matching import MATCHED_METHODS, SponsorMatcher
+
+logger = logging.getLogger("enrich_published")
+
+# Reuse the report script's loader and chamber derivation rather than
+# duplicating them; it is a script, not a package module.
+_REPORT = Path(__file__).with_name("run_matching_report.py")
+_spec = importlib.util.spec_from_file_location("_matching_report", _REPORT)
+_report = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_report)
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sessions", type=int, nargs="+", required=True)
+    parser.add_argument("--parquet-source", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--cache-dir", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def enrich_session(df, session: int, cache_dir: Path | None):
+    """Fill the four enrichment columns plus sponsor_chambers for one session."""
+    roster_kwargs = {"cache_dir": cache_dir} if cache_dir else {}
+    matcher = SponsorMatcher(get_roster(session, **roster_kwargs))
+
+    ids, parties, districts, confidences, chambers_col = [], [], [], [], []
+    matched = total = 0
+
+    for _, row in df.iterrows():
+        raw = row.get("sponsors")
+        sponsors = [] if raw is None else list(raw)
+        chambers = _report.chambers_for_row(row, sponsors)
+        results = matcher.match_all(sponsors, chambers=chambers)
+
+        ids.append([r.openstates_id if r.method in MATCHED_METHODS else None for r in results])
+        parties.append([r.party if r.method in MATCHED_METHODS else None for r in results])
+        districts.append([r.district if r.method in MATCHED_METHODS else None for r in results])
+        confidences.append([r.confidence if r.method in MATCHED_METHODS else None for r in results])
+        chambers_col.append(chambers)
+        total += len(sponsors)
+        matched += sum(1 for r in results if r.method in MATCHED_METHODS)
+
+    df = df.copy()
+    df["sponsor_chambers"] = chambers_col
+    df["sponsor_ids"] = ids
+    df["sponsor_parties"] = parties
+    df["sponsor_districts"] = districts
+    df["sponsor_match_confidence"] = confidences
+    rate = matched / total if total else 0.0
+    logger.info(f"Session {session}: enriched {matched}/{total} sponsor mentions ({rate:.1%})")
+    return df, {"session": session, "mentions": total, "matched": matched, "rate": round(rate, 4)}
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
+    args = parse_args(argv)
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    summary = []
+    for session in args.sessions:
+        logger.info(f"=== Session {session} ===")
+        df = _report.load_session_bills(args.parquet_source, session)
+        enriched, stats = enrich_session(df, session, args.cache_dir)
+
+        session_dir = args.output / str(session)
+        session_dir.mkdir(parents=True, exist_ok=True)
+        enriched.to_parquet(session_dir / "train-00000-of-00001.parquet", index=False)
+        summary.append(stats)
+
+    (args.output / "enrichment_summary.json").write_text(json.dumps(summary, indent=2))
+    logger.info(f"Wrote {len(summary)} enriched sessions to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/enrich_published.py
+++ b/scripts/enrich_published.py
@@ -42,6 +42,8 @@ logger = logging.getLogger("enrich_published")
 # duplicating them; it is a script, not a package module.
 _REPORT = Path(__file__).with_name("run_matching_report.py")
 _spec = importlib.util.spec_from_file_location("_matching_report", _REPORT)
+if _spec is None or _spec.loader is None:  # pragma: no cover - path/packaging error
+    raise ImportError(f"Cannot load the matching report helpers from {_REPORT}")
 _report = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_report)
 

--- a/src/maine_bills/openstates.py
+++ b/src/maine_bills/openstates.py
@@ -394,9 +394,14 @@ def _family_name_from_full(name: str) -> str:
 
 
 def default_provider() -> RosterProvider:
-    """Pick a provider: the v3 API if an API key is configured, else bulk data."""
-    if os.environ.get(OPENSTATES_API_KEY_ENV):
-        return OpenStatesAPIProvider()
+    """The people-repo provider, which is correct for every session.
+
+    Deliberately does NOT switch to the v3 API when OPENSTATES_API_KEY is set.
+    The v3 people endpoint reports only each person's *current* role, so using
+    it for a historical session silently builds that session's roster out of
+    today's membership. Merely configuring a key must not change how past
+    sessions are matched; callers who want the API provider pass it explicitly.
+    """
     return PeopleRepoProvider()
 
 

--- a/tests/unit/test_enrich_published.py
+++ b/tests/unit/test_enrich_published.py
@@ -1,0 +1,134 @@
+"""Tests for the enrich-in-place publishing path."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from maine_bills.openstates import RosterEntry, roster_cache_path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "enrich_published.py"
+
+
+@pytest.fixture(scope="module")
+def enrich_mod():
+    spec = importlib.util.spec_from_file_location("enrich_published", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _entry(os_id, name, family, chamber, district, party="Democratic"):
+    return RosterEntry(
+        openstates_id=os_id,
+        name=name,
+        family_name=family,
+        party=party,
+        chamber=chamber,
+        district=district,
+    )
+
+
+ROSTER = [
+    _entry("ocd-person/perry-a", "Anne Perry", "Perry", "House", "9"),
+    _entry("ocd-person/perry-j", "Joseph Perry", "Perry", "Senate", "31"),
+    _entry("ocd-person/daughtry", "Mattie Daughtry", "Daughtry", "Senate", "23"),
+]
+
+
+@pytest.fixture
+def source(tmp_path):
+    """A local parquet source plus a seeded roster cache."""
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    roster_cache_path(cache, 132).write_text(json.dumps([r.to_dict() for r in ROSTER]))
+
+    session_dir = tmp_path / "src" / "132"
+    session_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {
+                "session": 132,
+                "ld_number": "1",
+                "source_filename": "132-LD-1",
+                "sponsors": ["DAUGHTRY", "PERRY"],
+                "text": (
+                    "Presented by Senator DAUGHTRY of Cumberland.\n"
+                    "Cosponsored by Senator PERRY of Bangor.\nBe it enacted"
+                ),
+            },
+            {
+                "session": 132,
+                "ld_number": "2",
+                "source_filename": "132-LD-2",
+                "sponsors": ["PERRY"],
+                "text": "Presented by Representative PERRY of Calais.\nBe it enacted",
+            },
+            {
+                "session": 132,
+                "ld_number": "3",
+                "source_filename": "132-LD-3",
+                "sponsors": ["NOBODY"],
+                "text": "Presented by Senator NOBODY of Nowhere.\nBe it enacted",
+            },
+        ]
+    ).to_parquet(session_dir / "train-00000-of-00001.parquet", index=False)
+    return tmp_path / "src", cache
+
+
+def _run(enrich_mod, source, tmp_path):
+    src, cache = source
+    out = tmp_path / "out"
+    rc = enrich_mod.main(
+        [
+            "--sessions",
+            "132",
+            "--parquet-source",
+            str(src),
+            "--output",
+            str(out),
+            "--cache-dir",
+            str(cache),
+        ]
+    )
+    assert rc == 0
+    return pd.read_parquet(out / "132" / "train-00000-of-00001.parquet"), out
+
+
+def test_chamber_hint_splits_shared_surname(enrich_mod, source, tmp_path):
+    """The two Perrys must resolve to different legislators."""
+    df, _ = _run(enrich_mod, source, tmp_path)
+    assert list(df.sponsor_ids[0]) == ["ocd-person/daughtry", "ocd-person/perry-j"]
+    assert list(df.sponsor_ids[1]) == ["ocd-person/perry-a"]
+
+
+def test_unmatched_sponsor_stays_null(enrich_mod, source, tmp_path):
+    df, _ = _run(enrich_mod, source, tmp_path)
+    assert list(df.sponsor_ids[2]) == [None]
+    assert list(df.sponsor_parties[2]) == [None]
+
+
+def test_enrichment_columns_stay_aligned(enrich_mod, source, tmp_path):
+    df, _ = _run(enrich_mod, source, tmp_path)
+    for _, row in df.iterrows():
+        n = len(row.sponsors)
+        assert len(row.sponsor_chambers) == n
+        assert len(row.sponsor_ids) == n
+        assert len(row.sponsor_parties) == n
+        assert len(row.sponsor_districts) == n
+        assert len(row.sponsor_match_confidence) == n
+
+
+def test_original_sponsor_strings_untouched(enrich_mod, source, tmp_path):
+    """Provenance: enrichment must never rewrite the extracted names."""
+    df, _ = _run(enrich_mod, source, tmp_path)
+    assert list(df.sponsors[0]) == ["DAUGHTRY", "PERRY"]
+    assert list(df.sponsors[2]) == ["NOBODY"]
+
+
+def test_summary_reports_per_session_rate(enrich_mod, source, tmp_path):
+    _, out = _run(enrich_mod, source, tmp_path)
+    summary = json.loads((out / "enrichment_summary.json").read_text())
+    assert summary == [{"session": 132, "mentions": 4, "matched": 3, "rate": 0.75}]

--- a/tests/unit/test_openstates.py
+++ b/tests/unit/test_openstates.py
@@ -504,3 +504,18 @@ def test_consecutive_sessions_do_not_share_a_seat_holder():
     for session, expected in ((130, 1), (131, 1), (132, 0)):
         roster = roster_for_session([two_termer], session)
         assert len(roster) == expected, session
+
+
+def test_default_provider_ignores_the_api_key(monkeypatch):
+    """A configured key must not silently change historical roster construction.
+
+    The v3 API reports only current roles, so selecting it for session 121
+    would build a 2003 roster from today's membership.
+    """
+    from maine_bills.openstates import default_provider
+
+    monkeypatch.setenv("OPENSTATES_API_KEY", "some-key")
+    assert isinstance(default_provider(), PeopleRepoProvider)
+
+    monkeypatch.delenv("OPENSTATES_API_KEY", raising=False)
+    assert isinstance(default_provider(), PeopleRepoProvider)


### PR DESCRIPTION
## What

The path to actually publish v2. `scripts/enrich_published.py` reads each session's parquet from HuggingFace, fills the v2 sponsor columns, and writes them for a gated publish job to upload.

**Enrichment needs no PDFs.** `sponsors` is already published, and chamber hints come from the published `text`, which retains the `Presented by Senator X of Y` block. A full re-scrape of 121–132 is roughly **43,000 PDF downloads** and cannot finish inside a single job; this runs in minutes over exactly the data the Gate A report was computed from.

New `Enrich and Publish` workflow: an `enrich` job that produces the parquet plus a per-session match-rate table in the job summary, then a `publish` job gated on the **`huggingface-publish`** environment. The enriched parquet is downloadable and inspectable before anything reaches the Hub, and publish uploads exactly the reviewed artifact.

## Also: removes a provider trip-wire

`default_provider()` returned `OpenStatesAPIProvider` whenever `OPENSTATES_API_KEY` was set — but the v3 people endpoint reports only each person's **current** role. With the key configured (it's a repo secret), historical sessions would have had their rosters built from present-day membership. The Gate A run happened to use the people-repo provider, so this never fired, but it would have silently corrupted this publish. The people-repo provider is now always the default, matching what the module docstring already claimed; the API provider must be passed explicitly.

## Verified

End-to-end against a local parquet source with a seeded roster: the two Perrys split correctly by chamber (`Senator PERRY of Bangor` → Joseph, `Representative PERRY of Calais` → Anne), unmatched sponsors stay null, alignment holds on every row, and original `sponsors` strings are untouched. **289 tests pass, ruff clean.**

## Known caveats, to document in the card

- v1's `sponsors` was deduplicated by name, so a bill with two same-surname sponsors in different chambers has one entry and takes that surname's first-mentioned chamber. Full fidelity arrives with the next scrape (the dedup fix from #10 only applies at extraction time).
- Match rates vary widely by session — 14% on 121 to 98% on 132. The card should state them per session rather than averaging them away. Remaining gaps are tracked in #13.

## Risk summary

Outward-facing: this is what publishes v2. Enrichment is additive and null-safe — `sponsors`, `text`, and every v1 column pass through untouched, so a bad match can only produce nulls, never a rewritten record. The publish job cannot run without environment approval, and it uploads the same artifact you can download from the enrich job. The provider change alters which roster source is used when a key is set; that's a correctness fix, but it does change matching behavior in that configuration.

## Sequence

1. Merge #12 (report header) and this PR.
2. **Actions → Enrich and Publish → Run workflow** on `main`, sessions `121 … 132`.
3. Review the job summary table and artifact; approve the `publish` deployment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WicqsC1r64bRg1pbAqFsTV)_