### PR TITLE
[Tier-2] fix: extract cosponsors from plural roster lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,10 @@ opened by a `Senators:`/`Representatives:` label, and only when followed by
 - Title filter: 34 words blocking false positives (leadership titles, government entities, etc.)
 - Word-level filtering via `is_valid_name()` checks each word against title_words set
 - Hyphenated names normalized (stray spaces collapsed: `BEEBE- CENTER` → `BEEBE-CENTER`)
+- Roster lists: a chamber label (`Senators:` / `Representatives:`, singular or
+  plural) opens a contiguous comma-delimited run of bare surnames, which is how
+  widely cosponsored bills are printed. The run ends at the first cell that is
+  not a clean `NAME of LOCALITY`.
 - `sponsor_validation.py`: optional post-processing to filter against known legislator lists (e.g., OpenStates)
 
 ### Text Cleaning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,16 @@ Website → PDF list → Download PDF → TextExtractor → BillDocument
 
 ### Sponsor Extraction
 
-All sponsor patterns require a `Senator/Representative/President/Speaker` prefix — this prevents false positives from bill text like "Town of Brunswick" or "University of Maine".
+Sponsor patterns require a `Senator/Representative/President/Speaker` prefix —
+this prevents false positives from bill text like "Town of Brunswick" or
+"University of Maine".
+
+**Exception — roster lists.** Widely cosponsored bills name the chamber once and
+then list bare surnames: `Senators: BAILEY of York, BALDACCI of Penobscot, ...`.
+Those entries are read without an adjoining title, but only inside a segment
+opened by a `Senators:`/`Representatives:` label, and only when followed by
+` of <locality>`. The label also supplies the chamber. Without this, a
+99-cosponsor bill yields 2 sponsors — see `tests/unit/test_sponsor_roster_lists.py`.
 
 **Key details:**
 - Title filter: 34 words blocking false positives (leadership titles, government entities, etc.)

--- a/scripts/audit_roster_sweep.py
+++ b/scripts/audit_roster_sweep.py
@@ -113,6 +113,12 @@ def audit_session(parquet_source: str, session: int) -> dict:
         # acronym is obvious on sight next to a column of Maine surnames.
         "unmatched_names": [n for n, _c in unmatched.most_common()],
         "all_names": [[n, c] for n, c in contributed.most_common()],
+        # Names seen once or twice in a whole session. A sitting legislator
+        # cosponsors far more than that, so this tail is where a misparse
+        # shows up -- and unlike the roster check it works for 121-124, where
+        # OpenStates coverage is too poor to judge anything.
+        "singleton_names": sorted(n for n, c in contributed.items() if c == 1),
+        "rare_names": [f"{n}({c})" for n, c in contributed.most_common()[-25:]],
     }
 
 
@@ -149,6 +155,15 @@ def main(argv=None) -> int:
             # No roster to check against, so the names themselves are the
             # finding -- print them rather than reporting a silent zero.
             logger.info(f"  names: {', '.join(n for n, _c in result['all_names'][:60])}")
+
+        # The rare tail is where junk lives. A sitting legislator cosponsors
+        # many bills a session; a misparse appears once or twice. This is the
+        # roster-independent check, which matters because the OpenStates
+        # rosters are poor for 121-124 and cannot be used to judge those.
+        logger.info(
+            f"  distinct={result['distinct_names']} (chamber has ~186 seats); "
+            f"rarest: {result['rare_names']}"
+        )
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(results, indent=2))

--- a/scripts/audit_roster_sweep.py
+++ b/scripts/audit_roster_sweep.py
@@ -126,6 +126,10 @@ def parse_args(argv=None):
 
 def main(argv=None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
+    # One signed CDN URL per parquet range request, several per session, each
+    # hundreds of characters. They bury the only output anyone reads.
+    for noisy in ("httpx", "huggingface_hub", "urllib3", "filelock"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
     args = parse_args(argv)
 
     results = []
@@ -148,6 +152,22 @@ def main(argv=None) -> int:
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(results, indent=2))
+
+    # Repeated at the end as a table: this is the finding, and scrolling back
+    # through per-session logs to reassemble it is how it gets misread.
+    logger.info("=" * 72)
+    logger.info(
+        f"{'session':>8} {'bills':>7} {'+names':>8} {'distinct':>9} {'unmatched':>10} {'rate':>7}"
+    )
+    for r in results:
+        rate = "n/a" if r["unmatched_rate"] is None else f"{r['unmatched_rate']:.4f}"
+        flag = "" if r["roster_available"] else "  (no roster)"
+        logger.info(
+            f"{r['session']:>8} {r['bills']:>7} {r['names_contributed']:>8} "
+            f"{r['distinct_names']:>9} {r['unmatched_mentions']:>10} {rate:>7}{flag}"
+        )
+    total_unmatched = sum(r["unmatched_mentions"] for r in results)
+    logger.info(f"Total unmatched across all sessions: {total_unmatched}")
     logger.info(f"Wrote {args.output}")
     return 0
 

--- a/scripts/audit_roster_sweep.py
+++ b/scripts/audit_roster_sweep.py
@@ -11,16 +11,26 @@ constructed prose" (it can) but "does real bill text defeat it". That is an
 empirical question about the corpus, and this script answers it.
 
 Method: extract each session's sponsors twice, once with the sweep live and
-once with it disabled, and diff. The difference is exactly what the sweep
-contributed. Each contributed name is then matched against the OpenStates
-roster for that session -- a real surname matches a sitting legislator, an
-agency acronym does not -- and the unmatched names are printed in full so a
-human can see what they are.
+once with it disabled, and diff. Each contributed name is then matched against
+the OpenStates roster for that session -- a real surname matches a sitting
+legislator, an agency acronym does not -- and the unmatched names are printed
+in full so a human can see what they are.
 
-An unmatched name is not automatically a false positive: roster coverage for
-sessions 121-124 is poor (issue #13), so an unmatched name there is more
-likely a coverage gap than a bad extraction. Read the per-session split, not
-the total.
+**What this does and does not establish.** Three limits worth stating, because
+the numbers are easy to over-read:
+
+* The control is "this PR minus the roster sweep", NOT `main`. The wider
+  sponsor window and the rewritten block terminators are present in BOTH arms,
+  so their contribution is attributed to neither and is not measured here.
+* A zero unmatched count means "every contributed name matched the OpenStates
+  roster", not "no junk was captured". ``SponsorMatcher`` has a fuzzy fallback,
+  so a short token that happens to clear its threshold against some surname is
+  recorded as matched and never appears in the unmatched list. Reading
+  ``all_names`` is what would establish the stronger claim.
+* An unmatched name is not automatically a false positive: roster coverage for
+  sessions 121-124 is poor (issue #13), so an unmatched name there is more
+  likely a coverage gap than a bad extraction. Read the per-session split, not
+  the total.
 
 Usage:
     uv run python scripts/audit_roster_sweep.py --sessions 131 132
@@ -79,7 +89,11 @@ def audit_session(parquet_source: str, session: int) -> dict:
     contributed = Counter()
     bills_affected = 0
     for got, base in zip(with_sweep, without_sweep):
-        extra = [n for n in got if n not in set(base)]
+        # Multiset difference, not membership. `_extract_sponsors` dedupes on
+        # (name, chamber), so the same surname can legitimately appear twice --
+        # Representative PERRY of Calais and Senator PERRY of Bangor. A set
+        # comparison hid the second one and made every count a floor.
+        extra = Counter(got) - Counter(base)
         if extra:
             bills_affected += 1
             contributed.update(extra)

--- a/scripts/audit_roster_sweep.py
+++ b/scripts/audit_roster_sweep.py
@@ -107,9 +107,12 @@ def audit_session(parquet_source: str, session: int) -> dict:
         "unmatched_mentions": sum(unmatched.values()),
         "unmatched_rate": round(sum(unmatched.values()) / total, 4) if total else None,
         "roster_available": matcher is not None,
-        # The whole point of the audit: a human reads this list and decides
-        # whether these are legislators the roster is missing, or junk.
+        # The whole point of the audit: a human reads these and decides whether
+        # they are legislators the roster is missing, or junk. `all_names` is
+        # what makes the audit useful without a roster at all -- an agency
+        # acronym is obvious on sight next to a column of Maine surnames.
         "unmatched_names": [n for n, _c in unmatched.most_common()],
+        "all_names": [[n, c] for n, c in contributed.most_common()],
     }
 
 
@@ -138,6 +141,10 @@ def main(argv=None) -> int:
         )
         if result["unmatched_names"]:
             logger.info(f"  unmatched: {', '.join(result['unmatched_names'][:40])}")
+        elif not result["roster_available"]:
+            # No roster to check against, so the names themselves are the
+            # finding -- print them rather than reporting a silent zero.
+            logger.info(f"  names: {', '.join(n for n, _c in result['all_names'][:60])}")
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(results, indent=2))

--- a/scripts/audit_roster_sweep.py
+++ b/scripts/audit_roster_sweep.py
@@ -1,0 +1,149 @@
+"""Measure what the roster sweep contributes, and whether any of it is junk.
+
+The sweep reads bare surnames out of a "Senators:" / "Representatives:" roster
+in a cosponsor block. It is bounded by shape: a roster is a contiguous
+comma-delimited run of ``NAME of LOCALITY`` cells, and the first cell that is
+not one ends it.
+
+Shape alone cannot tell a surname from an acronym -- "DHHS of Augusta" parses
+exactly like "BAILEY of York". So the guard is not "can this be defeated by
+constructed prose" (it can) but "does real bill text defeat it". That is an
+empirical question about the corpus, and this script answers it.
+
+Method: extract each session's sponsors twice, once with the sweep live and
+once with it disabled, and diff. The difference is exactly what the sweep
+contributed. Each contributed name is then matched against the OpenStates
+roster for that session -- a real surname matches a sitting legislator, an
+agency acronym does not -- and the unmatched names are printed in full so a
+human can see what they are.
+
+An unmatched name is not automatically a false positive: roster coverage for
+sessions 121-124 is poor (issue #13), so an unmatched name there is more
+likely a coverage gap than a bad extraction. Read the per-session split, not
+the total.
+
+Usage:
+    uv run python scripts/audit_roster_sweep.py --sessions 131 132
+"""
+
+import argparse
+import importlib.util
+import json
+import logging
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from maine_bills import text_extractor as tx  # noqa: E402
+from maine_bills.openstates import get_roster  # noqa: E402
+from maine_bills.sponsor_matching import METHOD_UNMATCHED, SponsorMatcher  # noqa: E402
+
+logger = logging.getLogger("audit_roster_sweep")
+
+# A pattern that cannot match, used to switch the sweep off for the control run.
+_NEVER = re.compile(r"(?!x)x")
+
+
+def load_session_bills(parquet_source: str, session: int):
+    report_path = Path(__file__).with_name("run_matching_report.py")
+    spec = importlib.util.spec_from_file_location("_matching_report", report_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - packaging error
+        raise ImportError(f"Cannot load the parquet loader from {report_path}")
+    report = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(report)
+    return report.load_session_bills(parquet_source, session)
+
+
+def sponsors_for(texts, sweep: bool) -> list[list[str]]:
+    """Extract sponsors for every text, with the roster sweep on or off."""
+    extractor = tx.TextExtractor()
+    original = tx._ROSTER_SEGMENTS
+    if not sweep:
+        tx._ROSTER_SEGMENTS = _NEVER
+    try:
+        return [extractor._extract_sponsors(t if isinstance(t, str) else "") or [] for t in texts]
+    finally:
+        tx._ROSTER_SEGMENTS = original
+
+
+def audit_session(parquet_source: str, session: int) -> dict:
+    df = load_session_bills(parquet_source, session)
+    texts = list(df["text"])
+
+    with_sweep = sponsors_for(texts, sweep=True)
+    without_sweep = sponsors_for(texts, sweep=False)
+
+    contributed = Counter()
+    bills_affected = 0
+    for got, base in zip(with_sweep, without_sweep):
+        extra = [n for n in got if n not in set(base)]
+        if extra:
+            bills_affected += 1
+            contributed.update(extra)
+
+    try:
+        matcher = SponsorMatcher(roster=get_roster(session))
+    except Exception as e:
+        logger.warning(f"Session {session}: no roster ({type(e).__name__}: {e})")
+        matcher = None
+
+    unmatched = Counter()
+    if matcher is not None:
+        for name, count in contributed.items():
+            if matcher.match(name).method == METHOD_UNMATCHED:
+                unmatched[name] = count
+
+    total = sum(contributed.values())
+    return {
+        "session": session,
+        "bills": len(df),
+        "bills_gaining_sponsors": bills_affected,
+        "names_contributed": total,
+        "distinct_names": len(contributed),
+        "unmatched_distinct": len(unmatched),
+        "unmatched_mentions": sum(unmatched.values()),
+        "unmatched_rate": round(sum(unmatched.values()) / total, 4) if total else None,
+        "roster_available": matcher is not None,
+        # The whole point of the audit: a human reads this list and decides
+        # whether these are legislators the roster is missing, or junk.
+        "unmatched_names": [n for n, _c in unmatched.most_common()],
+    }
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--sessions", type=int, nargs="+", required=True)
+    p.add_argument("--parquet-source", default="hf://datasets/pem207/maine-bills")
+    p.add_argument("--output", type=Path, default=Path("report/roster-sweep-audit.json"))
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
+    args = parse_args(argv)
+
+    results = []
+    for session in args.sessions:
+        logger.info(f"Auditing session {session}")
+        result = audit_session(args.parquet_source, session)
+        results.append(result)
+        logger.info(
+            f"  +{result['names_contributed']} names on "
+            f"{result['bills_gaining_sponsors']} bills; "
+            f"{result['unmatched_mentions']} unmatched "
+            f"({result['unmatched_rate']})"
+        )
+        if result["unmatched_names"]:
+            logger.info(f"  unmatched: {', '.join(result['unmatched_names'][:40])}")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(results, indent=2))
+    logger.info(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/diagnose_sponsor_extraction.py
+++ b/scripts/diagnose_sponsor_extraction.py
@@ -165,7 +165,13 @@ def _sample(by_filename: pd.DataFrame, name: str, session: int, bucket: str) -> 
     row = by_filename.loc[name]
     if isinstance(row, pd.DataFrame):  # duplicate filenames, if any
         row = row.iloc[0]
-    text = row.get("text") or ""
+    # Same guard analyze_zero_sponsor_docs uses, and for the same reason: a null
+    # text cell is not always None. `pd.NA or ""` raises (its truth value is
+    # ambiguous), and NaN is *truthy*, so `or ""` hands back the float and the
+    # slice below fails instead. isinstance covers both.
+    text = row.get("text")
+    if not isinstance(text, str):
+        text = ""
     return {
         "session": session,
         "source_filename": name,

--- a/scripts/diagnose_sponsor_extraction.py
+++ b/scripts/diagnose_sponsor_extraction.py
@@ -139,23 +139,61 @@ def diagnose_session(df: pd.DataFrame, session: int, samples: int) -> tuple[dict
     # Sample the two buckets that indicate a real problem, in that order.
     interesting = buckets["marker_only"] + buckets["recoverable"]
     by_filename = originals.set_index("source_filename", drop=False)
-    text_samples = []
-    for name in interesting[:samples]:
-        row = by_filename.loc[name]
-        if isinstance(row, pd.DataFrame):  # duplicate filenames, if any
-            row = row.iloc[0]
-        text = row.get("text") or ""
-        text_samples.append(
-            {
-                "session": session,
-                "source_filename": name,
-                "bucket": "marker_only" if name in buckets["marker_only"] else "recoverable",
-                "reextracted": TextExtractor._extract_sponsor_mentions(text)[:10],
-                "text_head": text[:SAMPLE_CHARS],
-            }
+    text_samples = [
+        _sample(
+            by_filename,
+            name,
+            session,
+            "marker_only" if name in buckets["marker_only"] else "recoverable",
         )
+        for name in interesting[:samples]
+    ]
+
+    # Bills that *do* have sponsors, which the buckets above never show. A
+    # session can extract cleanly on every bill and still lose most sponsors if
+    # the block lists more names than the patterns pick up -- and re-running the
+    # same extractor cannot detect that, because it is what produced the counts.
+    # So the mentions/doc gap between sessions is only interpretable next to the
+    # raw block. Lowest counts first: one stored sponsor on a bill whose text
+    # names five is exactly the failure this is looking for.
+    text_samples += _low_sponsor_samples(originals, by_filename, session, samples)
 
     return result, text_samples
+
+
+def _sample(by_filename: pd.DataFrame, name: str, session: int, bucket: str) -> dict:
+    row = by_filename.loc[name]
+    if isinstance(row, pd.DataFrame):  # duplicate filenames, if any
+        row = row.iloc[0]
+    text = row.get("text") or ""
+    return {
+        "session": session,
+        "source_filename": name,
+        "bucket": bucket,
+        "stored_sponsors": as_aligned_list(row.get("sponsors")) or [],
+        "reextracted": TextExtractor._extract_sponsor_mentions(text)[:20],
+        "text_head": text[:SAMPLE_CHARS],
+    }
+
+
+def _low_sponsor_samples(
+    originals: pd.DataFrame, by_filename: pd.DataFrame, session: int, samples: int
+) -> list[dict]:
+    """Sampled bills that have sponsors, fewest first, then a high-count control."""
+    counts = originals["sponsors"].map(sponsor_count)
+    with_sponsors = originals[counts > 0].assign(_n=counts[counts > 0])
+    if with_sponsors.empty:
+        return []
+
+    ordered = with_sponsors.sort_values(["_n", "source_filename"])
+    low = list(ordered["source_filename"].head(samples))
+    # A couple of high-count bills from the same session as a control: if those
+    # parse fully, the format is fine and low counts are real.
+    high = list(ordered["source_filename"].tail(2))
+
+    return [_sample(by_filename, n, session, "has_sponsors_low") for n in low] + [
+        _sample(by_filename, n, session, "has_sponsors_high") for n in high
+    ]
 
 
 def format_markdown(results: list[dict]) -> str:

--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -38,7 +38,14 @@ _COSPONSOR_BLOCK = re.compile(
 
 # "Senators:" / "Representatives:" opens a run of bare surnames belonging to that
 # chamber, and runs until the next such label.
-_ROSTER_SEGMENTS = re.compile(r"\b(Senators|Representatives)\s*:")
+#
+# The SINGULAR forms count too. Maine routinely closes a roster with a
+# one-member trailing label -- "..., MAXMIN of Nobleboro, Senator: BLACK of
+# Franklin." -- and matching only the plural cost that entry AND terminated the
+# run before it, because "Senator: BLACK of Franklin" is not a well-formed cell.
+# Measured over 296 real bills this was the single largest loss class: 55 of 68
+# affected bills. rstrip("s") still yields the right singular chamber label.
+_ROSTER_SEGMENTS = re.compile(r"\b(Senators?|Representatives?)\s*:")
 
 # Rosters print surnames in capitals -- BAILEY, BEEBE-CENTER, LaFOUNTAIN,
 # TALBOT ROSS, DHALAC. Requiring two adjacent capitals is a positive shape test
@@ -98,10 +105,35 @@ _ROSTER_SURNAME = re.compile(r"[A-Z]{2}")
 _ROSTER_ENTRY = re.compile(
     r"^(?:(?P<title>Senator|Representative|President|Speaker)\s+)?"
     r"(?P<name>[A-Z][A-Za-z'\-]*(?:\s+[A-Z][A-Za-z'\-]*)?)"
-    r"\s+of\s+(?:the\s+)?"
-    r"(?:(?:St|Mt|Ft)\.\s+)?[A-Z][\w'\-]*(?:\s+[\w'\-]+){0,3}"
-    r"\s*(?:\.|$)"
+    r"\s+of\s+(?:"
+    r"the\s+(?:(?:St|Mt|Ft)\.\s+)?[A-Z][\w'\-]*(?:\s+[\w'\-]+){0,5}"
+    r"|(?:(?:St|Mt|Ft)\.\s+)?[A-Z][\w'\-]*(?:\s+[\w'\-]+){0,3}"
+    r")\s*(?:\.|$)"
 )
+
+
+# Words on the general title_words denylist that ARE real Maine surnames, and
+# so must not be filtered on the roster path.
+#
+# The denylist exists for the title-adjoining patterns, where "Hall" appears as
+# "City Hall". Inside a roster the same token is positionally a surname -- Rep.
+# Hall of Wilton sat in session 129 -- and the roster is already anchored to a
+# chamber label, so the false-positive risk that justifies the denylist
+# elsewhere is not present here.
+#
+# This became reachable only when the denylist was case-folded: before that it
+# matched nothing at all on this all-caps path, so activating it correctly also
+# activated this collision.
+_ROSTER_NAME_ALLOW = {"hall"}
+
+
+def _roster_name_ok(name: str, is_valid_name) -> bool:
+    """Whether a roster cell's name should be kept."""
+    if not _ROSTER_SURNAME.search(name):
+        return False
+    if name.casefold() in _ROSTER_NAME_ALLOW:
+        return True
+    return is_valid_name(name)
 
 
 def _roster_names(segment: str, is_valid_name):
@@ -130,11 +162,17 @@ def _roster_names(segment: str, is_valid_name):
         name = match.group("name").strip()
         # Rosters print surnames in capitals -- BAILEY, BEEBE-CENTER,
         # LaFOUNTAIN, TALBOT ROSS, DHALAC. Two adjacent capitals is a positive
-        # shape test on the name itself, which is what the sweep actually needs;
-        # is_valid_name alone is a 34-word denylist that does not contain City,
-        # Village, Board, University, Nation or Region.
-        if not is_valid_name(name) or not _ROSTER_SURNAME.search(name):
-            return
+        # shape test on the name itself, which is what the sweep actually needs.
+        #
+        # A rejection here SKIPS the cell; it does not end the run. The cell
+        # matched _ROSTER_ENTRY, so we are still plainly inside a roster -- only
+        # this one name looked wrong. Ending the run instead was a cascade: on
+        # session 129 HP0037 the real entry "HALL of Wilton" hit the denylist
+        # and took HICKMAN, INGWERSEN, MAXMIN, O'NEIL and BLACK down with it,
+        # six lost from one collision. The run-ending cases are the two above --
+        # a cell that is not an entry at all, and a cell with prose behind it.
+        if not _roster_name_ok(name, is_valid_name):
+            continue
         yield name, match.group("title")
         if match.end() < len(cell):
             return

--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -27,9 +27,13 @@ _SPONSOR_WINDOW = 8000
 # patterns could pick up "Senator X of Y" out of the bill's body text.
 _COSPONSOR_BLOCK = re.compile(
     r"Cosponsored by\s+(.+?)"
-    r"(?=Be it enacted|Emergency preamble|Preamble\.|Resolved:|SUMMARY"
-    r"|Sec\.\s*\d|Amend the bill|Amend the amendment|Presented by|Introduced by|$)",
-    re.DOTALL | re.IGNORECASE,
+    # Case-insensitivity is scoped to the terminators alone. Applied to the
+    # whole pattern it widened the OPENER too, so a prose "cosponsored by"
+    # inside the window opened a block where none existed.
+    r"(?=(?i:Be it enacted|Emergency preamble|Preamble\.|Resolved:|SUMMARY"
+    r"|Sec\.\s*[A-Za-z0-9]|Amend the (?:bill|resolve|amendment))"
+    r"|Presented by|Introduced by|$)",
+    re.DOTALL,
 )
 
 # "Senators:" / "Representatives:" opens a run of bare surnames belonging to that
@@ -52,11 +56,64 @@ _ROSTER_SURNAME = re.compile(r"[A-Z]{2}")
 
 # One roster entry: an optional individual title (leaders keep theirs inside the
 # list), a one- or two-word surname, then the mandatory " of <locality>".
+#
+# Matched as a PREFIX of its cell, not end-anchored. End-anchoring is the
+# obvious reading of "the locality must consume the cell", and it is wrong: when
+# a block does not terminate, the last cell of the roster always runs on into
+# the following prose with no comma to bound it --
+#
+#     Cosponsored by Senators: BAILEY of York. The department shall consider...
+#
+# so end-anchoring silently dropped the last name of every unterminated roster,
+# and the whole list where there was only one. What the cell boundary is for is
+# deciding whether to CONTINUE, which _roster_names handles: a cell the entry
+# does not consume ends the run after its name is taken.
+#
+# The locality is bounded by WORD COUNT rather than by capitalization. Requiring
+# every word to be capitalized looked tidier and rejected real places -- "Isle
+# au Haut" has a lowercase particle -- while a four-word ceiling still excludes
+# the prose runs this is guarding against.
 _ROSTER_ENTRY = re.compile(
     r"^(?:(?P<title>Senator|Representative|President|Speaker)\s+)?"
     r"(?P<name>[A-Z][A-Za-z'\-]*(?:\s+[A-Z][A-Za-z'\-]*)?)"
-    r"\s+of\s+\S"
+    r"\s+of\s+(?:the\s+)?[A-Z][\w.'\-]*(?:\s+[\w.'\-]+){0,3}\s*\.?"
 )
+
+
+def _roster_names(segment: str, is_valid_name):
+    """Yield (name, title) for the roster run at the start of ``segment``.
+
+    ``is_valid_name`` is the caller's title-word filter, which is built from the
+    per-call title_words set and so cannot live at module scope.
+
+    A roster is a CONTIGUOUS comma-delimited run: the run ends at the first cell
+    that is not a clean "NAME of LOCALITY". Three outcomes per cell:
+
+    * consumed entirely  -> a clean entry; take it and keep going
+    * matched as a prefix -> the roster's last entry, with prose behind it; take
+      it and stop, so the prose is never read
+    * no match            -> not an entry; stop without taking anything
+
+    Skipping bad cells instead of stopping is what let body text far past the
+    end of the roster still be harvested, because prose always intervenes and
+    was simply stepped over.
+    """
+    for cell in segment.split(","):
+        cell = cell.strip()
+        match = _ROSTER_ENTRY.match(cell)
+        if not match:
+            return
+        name = match.group("name").strip()
+        # Rosters print surnames in capitals -- BAILEY, BEEBE-CENTER,
+        # LaFOUNTAIN, TALBOT ROSS, DHALAC. Two adjacent capitals is a positive
+        # shape test on the name itself, which is what the sweep actually needs;
+        # is_valid_name alone is a 34-word denylist that does not contain City,
+        # Village, Board, University, Nation or Region.
+        if not is_valid_name(name) or not _ROSTER_SURNAME.search(name):
+            return
+        yield name, match.group("title")
+        if match.end() < len(cell):
+            return
 
 
 def _roster_segments(block: str) -> list[tuple[str, str]]:
@@ -438,14 +495,7 @@ class TextExtractor:
             # the old sweep produced.
             for label, segment in _roster_segments(cosp_block):
                 segment_chamber = _CHAMBER_BY_TITLE[label]
-                for entry in segment.split(","):
-                    entry_match = _ROSTER_ENTRY.match(entry.strip())
-                    if not entry_match:
-                        continue
-                    name = entry_match.group("name").strip()
-                    if not is_valid_name(name) or not _ROSTER_SURNAME.search(name):
-                        continue
-                    title = entry_match.group("title")
+                for name, title in _roster_names(segment, is_valid_name):
                     chamber = _CHAMBER_BY_TITLE.get(title) if title else segment_chamber
                     sponsors.append((name, chamber))
 

--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -44,14 +44,17 @@ _ROSTER_SEGMENTS = re.compile(r"\b(Senators|Representatives)\s*:")
 # TALBOT ROSS, DHALAC. Requiring two adjacent capitals is a positive shape test
 # on the name itself, which is what the sweep actually needs.
 #
-# Anchoring to the plural label was NOT sufficient on its own: the only other
-# guard was is_valid_name, a 34-word denylist that does not contain City,
-# Village, Board, University, Nation or Region -- the vocabulary of bill body
-# text. So the sweep was safe only while the cosponsor block terminated before
-# the body, and the terminator list is a denylist with reachable gaps:
-# amendments open "Amend the bill by", which matches none of them, and
-# amendments are ~45% of a session's documents. Verified: an amendment fixture
-# captured ("Village", "House") as a sponsor before this guard.
+# Anchoring to the plural label was NOT sufficient on its own, and neither was
+# is_valid_name: that denylist is written in Title Case and was compared
+# case-sensitively, so on this path -- which is ALL CAPS by construction -- it
+# matched nothing at all. Both guards now do real work: is_valid_name compares
+# case-folded and has been extended with the institutional vocabulary (City,
+# Village, Board, University, Nation, Region, Part, Chapter, ...), and this
+# pattern rejects the Title Case forms, which have no two adjacent capitals.
+#
+# Each is isolated by a test that goes red when only that guard is removed --
+# an earlier round's fixtures were subsumed by the prefix parse and passed with
+# either guard deleted.
 _ROSTER_SURNAME = re.compile(r"[A-Z]{2}")
 
 # One roster entry: an optional individual title (leaders keep theirs inside the
@@ -69,14 +72,35 @@ _ROSTER_SURNAME = re.compile(r"[A-Z]{2}")
 # deciding whether to CONTINUE, which _roster_names handles: a cell the entry
 # does not consume ends the run after its name is taken.
 #
-# The locality is bounded by WORD COUNT rather than by capitalization. Requiring
-# every word to be capitalized looked tidier and rejected real places -- "Isle
-# au Haut" has a lowercase particle -- while a four-word ceiling still excludes
-# the prose runs this is guarding against.
+# The locality is bounded by word count rather than by capitalization --
+# requiring every word to be capitalized rejects real places, since "Isle au
+# Haut" has a lowercase particle -- AND it must end at a sentence period or the
+# end of the cell. That boundary is what separates a locality from a sentence
+# that merely begins like one:
+#
+#     BAILEY of York, MDOT of Augusta shall study the matter.
+#
+# "Augusta shall study the matter" is inside the four-word ceiling, so without
+# the boundary MDOT is taken as a cosponsor. With it, the cell does not match at
+# all and the run stops -- which is the correct reading, because a roster cell
+# is a noun phrase and this one is a clause.
+#
+# The leading "St.|Mt.|Ft." arm keeps abbreviated place names whole: "St.
+# Albans", "St. George", "Mt. Desert". Without it the period inside the
+# abbreviation reads as the sentence boundary and the roster stops one town
+# early.
+#
+# It is an explicit list, not a general "period then capitalised word". The
+# general form re-opens the hole the boundary was added to close, because
+# ". The" satisfies it -- so "BAILEY of York. The department shall report"
+# matches as ONE complete cell, the run never stops, and every cell behind the
+# prose is harvested. Caught by test_the_prefix_branch_stops_the_run.
 _ROSTER_ENTRY = re.compile(
     r"^(?:(?P<title>Senator|Representative|President|Speaker)\s+)?"
     r"(?P<name>[A-Z][A-Za-z'\-]*(?:\s+[A-Z][A-Za-z'\-]*)?)"
-    r"\s+of\s+(?:the\s+)?[A-Z][\w.'\-]*(?:\s+[\w.'\-]+){0,3}\s*\.?"
+    r"\s+of\s+(?:the\s+)?"
+    r"(?:(?:St|Mt|Ft)\.\s+)?[A-Z][\w'\-]*(?:\s+[\w'\-]+){0,3}"
+    r"\s*(?:\.|$)"
 )
 
 
@@ -432,7 +456,40 @@ class TextExtractor:
             "County",
             "District",
             "Districts",
+            # Institutional and structural nouns. These reach the roster path
+            # because it is all-caps and the entry pattern only requires
+            # "<CAPS> of <Place>" -- "CITY of Portland" and "PART A of Chapter
+            # 12" are both well-formed entries by shape. The comment on
+            # _ROSTER_SURNAME used to claim that guard covered this vocabulary;
+            # it does not, since an all-caps common noun has two adjacent
+            # capitals like any surname.
+            #
+            # Chosen to exclude anything plausible as a Maine surname. "Hall"
+            # and "Chamber" above already make that tradeoff; these do not --
+            # no Maine legislator is surnamed City, Village or University.
+            "City",
+            "Village",
+            "Board",
+            "University",
+            "Nation",
+            "Region",
+            "Authority",
+            "Agency",
+            "Division",
+            "Institute",
+            "Association",
+            "Foundation",
+            "Corporation",
+            "Part",
+            "Chapter",
+            "Section",
+            "Subsection",
+            "Title",
+            "Article",
+            "Paragraph",
         }
+
+        _TITLE_WORDS_FOLDED = {word.casefold() for word in title_words}
 
         # Helper function to validate names
         def is_valid_name(name: str) -> bool:
@@ -442,9 +499,15 @@ class TextExtractor:
             # legislator who shares a surname but sits in the other chamber.
             if not name or len(name.split()) > 2:
                 return False
-            # Check if any word in the name is a title word (word-level filtering)
-            name_words = set(name.split())
-            return not name_words.intersection(title_words)
+            # Compared case-INSENSITIVELY. title_words is written in Title Case
+            # and rosters print surnames in capitals, so a case-sensitive
+            # intersection made this filter structurally inert on the roster
+            # path -- every word on the list passed in caps. COUNTY, DEPARTMENT,
+            # SENATE, LEGISLATURE, UNIVERSITY and NATION were all reachable as
+            # "sponsors" while the list that names them looked like it was doing
+            # the work.
+            name_words = {word.casefold() for word in name.split()}
+            return not name_words.intersection(_TITLE_WORDS_FOLDED)
 
         # Pattern 1: "Presented by Senator/Representative/President/Speaker NAME [of DISTRICT]"
         pattern1 = r"(?:Presented|Introduced) by\s+(?P<title>Senator|Representative|President|Speaker)\s+(?P<name>[A-Z][A-Za-z\'\-]+(?:\s+[A-Z][A-Za-z\'\-]+)?)\s+of\s+[A-Za-z\s]+"  # noqa: E501

--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -16,6 +16,51 @@ _CHAMBER_BY_TITLE = {
     "Speaker": "House",
 }
 
+# How far into the document to look for the sponsor block. A bill cosponsored by
+# most of a chamber runs to ~100 entries of roughly 30 characters each, so the
+# old 2,500-character window truncated the list itself: LD 2007 of session 131
+# has 99 cosponsors and its block alone exceeds 3,000 characters.
+_SPONSOR_WINDOW = 8000
+
+# Where the sponsor block ends. Worth being explicit now that the window is wide
+# -- without these the block would run to the window edge and the title-adjoining
+# patterns could pick up "Senator X of Y" out of the bill's body text.
+_COSPONSOR_BLOCK = re.compile(
+    r"Cosponsored by\s+(.+?)"
+    r"(?=Be it enacted|Emergency preamble|Preamble\.|Resolved:|SUMMARY"
+    r"|Sec\.\s*\d|Presented by|Introduced by|$)",
+    re.DOTALL,
+)
+
+# "Senators:" / "Representatives:" opens a run of bare surnames belonging to that
+# chamber, and runs until the next such label.
+_ROSTER_SEGMENTS = re.compile(r"\b(Senators|Representatives)\s*:")
+
+# One roster entry: an optional individual title (leaders keep theirs inside the
+# list), a one- or two-word surname, then the mandatory " of <locality>". The
+# locality is what makes an entry an entry -- requiring it is what keeps this
+# from matching ordinary prose.
+_ROSTER_ENTRY = re.compile(
+    r"^(?:(?P<title>Senator|Representative|President|Speaker)\s+)?"
+    r"(?P<name>[A-Z][A-Za-z'\-]*(?:\s+[A-Z][A-Za-z'\-]*)?)"
+    r"\s+of\s+\S"
+)
+
+
+def _roster_segments(block: str) -> list[tuple[str, str]]:
+    """Split a cosponsor block into (singular chamber title, segment) pairs.
+
+    Returns nothing when the block has no plural labels, which is the common
+    case: most bills list a handful of cosponsors, each with its own title.
+    """
+    matches = list(_ROSTER_SEGMENTS.finditer(block))
+    segments = []
+    for i, match in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(block)
+        label = match.group(1).rstrip("s")  # "Senators" -> "Senator"
+        segments.append((label, block[match.end() : end]))
+    return segments
+
 
 @dataclass
 class BillDocument:
@@ -263,7 +308,7 @@ class TextExtractor:
         Supports both "Presented by" (real bills) and "Introduced by" (some bills/tests).
         """
         sponsors: list[tuple[str, str | None]] = []
-        search_text = text[:2500]
+        search_text = text[:_SPONSOR_WINDOW]
         normalized_text = " ".join(search_text.split())
         # Normalize stray spaces around hyphens in names (e.g., "BEEBE- CENTER" -> "BEEBE-CENTER")
         normalized_text = re.sub(r"([A-Z])\s*-\s*([A-Z])", r"\1-\2", normalized_text)
@@ -348,11 +393,7 @@ class TextExtractor:
                 sponsors.append((name, _CHAMBER_BY_TITLE.get(match.group("title"))))
 
         # Pattern 2: Cosponsorship block
-        cosp_block_match = re.search(
-            r"Cosponsored by\s+(.+?)(?=\n\n|Be it enacted|Presented by|Introduced by|$)",
-            normalized_text,
-            re.DOTALL,
-        )  # noqa: E501
+        cosp_block_match = _COSPONSOR_BLOCK.search(normalized_text)
         if cosp_block_match:
             cosp_block = " ".join(cosp_block_match.group(1).split())
 
@@ -369,6 +410,32 @@ class TextExtractor:
                 name = match.group("name").strip()
                 if is_valid_name(name):
                     sponsors.append((name, _CHAMBER_BY_TITLE.get(match.group("title"))))
+
+            # Roster lists: "Senators: BAILEY of York, BALDACCI of Penobscot, ..."
+            #
+            # Widely cosponsored bills label the chamber ONCE and then list bare
+            # surnames, so the patterns above — which need a title adjoining each
+            # name — collect only the handful carrying their own (President,
+            # Speaker). On a 99-cosponsor bill that is 2 names out of 99.
+            #
+            # A bare-name sweep was removed in 300cd207 for producing garbage: it
+            # matched any "Capitalized of Somewhere" anywhere in the block. This
+            # is anchored instead — names are only read inside a segment opened by
+            # a plural chamber label, which both bounds the search and supplies
+            # the chamber, so these entries arrive better identified than the ones
+            # the old sweep produced.
+            for label, segment in _roster_segments(cosp_block):
+                segment_chamber = _CHAMBER_BY_TITLE[label]
+                for entry in segment.split(","):
+                    entry_match = _ROSTER_ENTRY.match(entry.strip())
+                    if not entry_match:
+                        continue
+                    name = entry_match.group("name").strip()
+                    if not is_valid_name(name):
+                        continue
+                    title = entry_match.group("title")
+                    chamber = _CHAMBER_BY_TITLE.get(title) if title else segment_chamber
+                    sponsors.append((name, chamber))
 
         # Normalize hyphenated names with stray spaces (e.g., "BEEBE- CENTER" -> "BEEBE-CENTER")
         sponsors = [(re.sub(r"\s*-\s*", "-", name), chamber) for name, chamber in sponsors]

--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -143,16 +143,21 @@ def _roster_names(segment: str, is_valid_name):
     per-call title_words set and so cannot live at module scope.
 
     A roster is a CONTIGUOUS comma-delimited run: the run ends at the first cell
-    that is not a clean "NAME of LOCALITY". Three outcomes per cell:
+    that is not a clean "NAME of LOCALITY". Four outcomes per cell:
 
-    * consumed entirely  -> a clean entry; take it and keep going
-    * matched as a prefix -> the roster's last entry, with prose behind it; take
-      it and stop, so the prose is never read
+    * consumed entirely, name kept    -> a clean entry; take it and keep going
+    * consumed entirely, name rejected -> skip the cell, keep going: the cell
+      IS an entry, only this one name looked wrong, and ending the run here
+      cascades (see the HALL case below)
+    * matched as a prefix -> prose behind it. Take the name if it passed, then
+      stop either way, so the prose is never read
     * no match            -> not an entry; stop without taking anything
 
-    Skipping bad cells instead of stopping is what let body text far past the
-    end of the roster still be harvested, because prose always intervenes and
-    was simply stepped over.
+    The prefix case must stop EVEN WHEN THE NAME WAS REJECTED. Ordering the
+    rejection first skipped that stop, so a rejected name on a prose-trailing
+    cell let the run continue into body text -- which is precisely what the
+    stop exists to prevent. Zero occurrences in 271 real bills, but the
+    docstring above claimed prose is never read, and it has to be true.
     """
     for cell in segment.split(","):
         cell = cell.strip()
@@ -172,6 +177,9 @@ def _roster_names(segment: str, is_valid_name):
         # six lost from one collision. The run-ending cases are the two above --
         # a cell that is not an entry at all, and a cell with prose behind it.
         if not _roster_name_ok(name, is_valid_name):
+            # Still honour the prose-behind-it stop; only the NAME is skipped.
+            if match.end() < len(cell):
+                return
             continue
         yield name, match.group("title")
         if match.end() < len(cell):
@@ -181,8 +189,10 @@ def _roster_names(segment: str, is_valid_name):
 def _roster_segments(block: str) -> list[tuple[str, str]]:
     """Split a cosponsor block into (singular chamber title, segment) pairs.
 
-    Returns nothing when the block has no plural labels, which is the common
-    case: most bills list a handful of cosponsors, each with its own title.
+    Returns nothing when the block has no chamber labels at all, which is the
+    common case: most bills list a handful of cosponsors, each carrying its own
+    title. Both the plural and singular forms open a segment -- Maine closes a
+    roster with a one-member "Senator: BLACK of Franklin".
     """
     matches = list(_ROSTER_SEGMENTS.finditer(block))
     segments = []

--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -28,18 +28,30 @@ _SPONSOR_WINDOW = 8000
 _COSPONSOR_BLOCK = re.compile(
     r"Cosponsored by\s+(.+?)"
     r"(?=Be it enacted|Emergency preamble|Preamble\.|Resolved:|SUMMARY"
-    r"|Sec\.\s*\d|Presented by|Introduced by|$)",
-    re.DOTALL,
+    r"|Sec\.\s*\d|Amend the bill|Amend the amendment|Presented by|Introduced by|$)",
+    re.DOTALL | re.IGNORECASE,
 )
 
 # "Senators:" / "Representatives:" opens a run of bare surnames belonging to that
 # chamber, and runs until the next such label.
 _ROSTER_SEGMENTS = re.compile(r"\b(Senators|Representatives)\s*:")
 
+# Rosters print surnames in capitals -- BAILEY, BEEBE-CENTER, LaFOUNTAIN,
+# TALBOT ROSS, DHALAC. Requiring two adjacent capitals is a positive shape test
+# on the name itself, which is what the sweep actually needs.
+#
+# Anchoring to the plural label was NOT sufficient on its own: the only other
+# guard was is_valid_name, a 34-word denylist that does not contain City,
+# Village, Board, University, Nation or Region -- the vocabulary of bill body
+# text. So the sweep was safe only while the cosponsor block terminated before
+# the body, and the terminator list is a denylist with reachable gaps:
+# amendments open "Amend the bill by", which matches none of them, and
+# amendments are ~45% of a session's documents. Verified: an amendment fixture
+# captured ("Village", "House") as a sponsor before this guard.
+_ROSTER_SURNAME = re.compile(r"[A-Z]{2}")
+
 # One roster entry: an optional individual title (leaders keep theirs inside the
-# list), a one- or two-word surname, then the mandatory " of <locality>". The
-# locality is what makes an entry an entry -- requiring it is what keeps this
-# from matching ordinary prose.
+# list), a one- or two-word surname, then the mandatory " of <locality>".
 _ROSTER_ENTRY = re.compile(
     r"^(?:(?P<title>Senator|Representative|President|Speaker)\s+)?"
     r"(?P<name>[A-Z][A-Za-z'\-]*(?:\s+[A-Z][A-Za-z'\-]*)?)"
@@ -431,7 +443,7 @@ class TextExtractor:
                     if not entry_match:
                         continue
                     name = entry_match.group("name").strip()
-                    if not is_valid_name(name):
+                    if not is_valid_name(name) or not _ROSTER_SURNAME.search(name):
                         continue
                     title = entry_match.group("title")
                     chamber = _CHAMBER_BY_TITLE.get(title) if title else segment_chamber

--- a/tests/unit/test_diagnose_sponsor_extraction.py
+++ b/tests/unit/test_diagnose_sponsor_extraction.py
@@ -175,12 +175,63 @@ def test_diagnose_session_buckets_only_originals(diag):
 
 def test_diagnose_session_samples_the_problem_buckets(diag):
     _, samples = diag.diagnose_session(_session_frame(), 132, samples=5)
-    assert [s["source_filename"] for s in samples] == ["132-LD-0002"]
-    sample = samples[0]
+    problem = [s for s in samples if s["bucket"] in ("recoverable", "marker_only")]
+    assert [s["source_filename"] for s in problem] == ["132-LD-0002"]
+    sample = problem[0]
     assert sample["bucket"] == "recoverable"
     assert sample["session"] == 132
     assert ("DAUGHTRY", "Senate") in [tuple(m) for m in sample["reextracted"]]
     assert sample["text_head"].startswith("STATE OF MAINE")
+
+
+# --- sampling bills that DO have sponsors ---
+
+
+def _mixed_frame():
+    """Three sponsored bills with 1, 2 and 4 stored sponsors."""
+    return pd.DataFrame(
+        [
+            _row("132-LD-0010", ["ONLYONE"], SPONSOR_BLOCK),
+            _row("132-LD-0011", ["A", "B"], SPONSOR_BLOCK),
+            _row("132-LD-0012", ["A", "B", "C", "D"], SPONSOR_BLOCK),
+            _row("132-LD-0013", [], "Be it enacted."),
+        ]
+    )
+
+
+def test_low_sponsor_samples_lead_with_the_fewest(diag):
+    _, samples = diag.diagnose_session(_mixed_frame(), 132, samples=1)
+    low = [s for s in samples if s["bucket"] == "has_sponsors_low"]
+    assert [s["source_filename"] for s in low] == ["132-LD-0010"]
+    assert low[0]["stored_sponsors"] == ["ONLYONE"]
+
+
+def test_high_sponsor_control_is_included(diag):
+    _, samples = diag.diagnose_session(_mixed_frame(), 132, samples=1)
+    high = [s for s in samples if s["bucket"] == "has_sponsors_high"]
+    assert [s["source_filename"] for s in high] == ["132-LD-0011", "132-LD-0012"]
+
+
+def test_samples_expose_stored_vs_reextracted(diag):
+    """The whole point: what the record holds, next to what the text says."""
+    _, samples = diag.diagnose_session(_mixed_frame(), 132, samples=1)
+    low = next(s for s in samples if s["bucket"] == "has_sponsors_low")
+    assert low["stored_sponsors"] == ["ONLYONE"]
+    # The text names two people, so the record is demonstrably losing sponsors.
+    assert len(low["reextracted"]) == 2
+    assert low["text_head"].startswith("STATE OF MAINE")
+
+
+def test_unsponsored_bills_are_never_sampled_as_healthy(diag):
+    _, samples = diag.diagnose_session(_mixed_frame(), 132, samples=1)
+    healthy = [s for s in samples if s["bucket"].startswith("has_sponsors")]
+    assert "132-LD-0013" not in [s["source_filename"] for s in healthy]
+
+
+def test_no_healthy_samples_when_nothing_has_sponsors(diag):
+    df = pd.DataFrame([_row("132-LD-0020", [], "Be it enacted.")])
+    _, samples = diag.diagnose_session(df, 132, samples=3)
+    assert [s for s in samples if s["bucket"].startswith("has_sponsors")] == []
 
 
 def test_sample_count_is_capped(diag):

--- a/tests/unit/test_diagnose_sponsor_extraction.py
+++ b/tests/unit/test_diagnose_sponsor_extraction.py
@@ -234,6 +234,24 @@ def test_no_healthy_samples_when_nothing_has_sponsors(diag):
     assert [s for s in samples if s["bucket"].startswith("has_sponsors")] == []
 
 
+@pytest.mark.parametrize("null_text", [None, pd.NA, np.nan])
+def test_sampling_survives_a_null_text_cell(diag, null_text):
+    """A sponsored bill with null text must not crash the sampler.
+
+    `pd.NA or ""` raises outright; NaN is truthy, so `or ""` yields the float
+    and the text slice fails instead. Both reach _sample only through the
+    has-sponsors path, which cannot pre-filter on text the way the zero-sponsor
+    buckets do.
+    """
+    df = pd.DataFrame([_row("132-LD-0030", ["DAUGHTRY"], null_text)])
+    _, samples = diag.diagnose_session(df, 132, samples=3)
+
+    sample = next(s for s in samples if s["bucket"] == "has_sponsors_low")
+    assert sample["text_head"] == ""
+    assert sample["reextracted"] == []
+    assert sample["stored_sponsors"] == ["DAUGHTRY"]
+
+
 def test_sample_count_is_capped(diag):
     rows = [_row(f"132-LD-{i:04d}", [], SPONSOR_BLOCK) for i in range(20)]
     _, samples = diag.diagnose_session(pd.DataFrame(rows), 132, samples=3)

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -1,0 +1,210 @@
+"""Sponsor extraction from plural roster lists.
+
+Widely cosponsored bills name the chamber once and then list bare surnames:
+
+    Cosponsored by Representative CARLOW of Buxton and
+    Senators: BAILEY of York, BALDACCI of Penobscot, ...
+
+Every pattern that needs a title adjoining the name collects only the few
+entries carrying their own (President, Speaker), so a 99-cosponsor bill yielded
+2 sponsors. A bare-name sweep existed until 300cd207 removed it for matching any
+"Capitalized of Somewhere" in the block; this replacement is anchored to the
+plural label, which bounds the search and supplies the chamber.
+
+The fixtures below are the real opening text of the two worst cases found in the
+published dataset, session 131 LD 1817 (96 stored sponsors) and LD 2007 (99).
+"""
+
+from maine_bills.text_extractor import TextExtractor
+
+LD_1817 = (
+    "Presented by Senator BRENNER of Cumberland.\n"
+    "Cosponsored by Representative CARLOW of Buxton and\n"
+    "Senators: BAILEY of York, BALDACCI of Penobscot, BEEBE-CENTER of Knox, "
+    "BENNETT of Oxford, BLACK of Franklin, BRAKEY of Androscoggin, "
+    "CARNEY of Cumberland, CHIPMAN of Cumberland, CURRY of Waldo, "
+    "DAUGHTRY of Cumberland, DUSON of Cumberland, FARRIN of Somerset, "
+    "GROHOSKI of Hancock, GUERIN of Penobscot, HARRINGTON of York, "
+    "HICKMAN of Kennebec, INGWERSEN of York, President JACKSON of Aroostook, "
+    "KEIM of Oxford, LaFOUNTAIN of Kennebec, LAWRENCE of York, "
+    "LIBBY of Cumberland, LYFORD of Penobscot.\n"
+    "Be it enacted by the People of the State of Maine as follows:\n"
+)
+
+LD_2007 = (
+    "Presented by Speaker TALBOT ROSS of Portland.\n"
+    "Cosponsored by President JACKSON of Aroostook and\n"
+    "Representatives: ABDI of Lewiston, ANDREWS of Paris, ANKELES of Brunswick, "
+    "ARFORD of Brunswick, BABIN of Fort Fairfield, BELL of Yarmouth, "
+    "BOYER of Poland, BOYLE of Gorham, BRENNAN of Portland, "
+    "CARMICHAEL of Greenbush, CLOUTIER of Lewiston, CLUCHEY of Bowdoinham, "
+    "COLLINGS of Portland, COPELAND of Saco, CRAFTS of Newcastle, "
+    "CRAVEN of Lewiston, CROCKETT of Portland, DANA of the Passamaquoddy Tribe, "
+    "DHALAC of South Portland, DILL of Old Town, DODGE of Belfast, "
+    "DOUDERA of Camden, EATON of Deer Isle.\n"
+    "Be it enacted by the People of the State of Maine as follows:\n"
+)
+
+
+def names(text):
+    return TextExtractor._extract_sponsors(text)
+
+
+def mentions(text):
+    return dict(TextExtractor._extract_sponsor_mentions(text))
+
+
+# --- the regression itself ---
+
+
+def test_roster_list_yields_every_cosponsor():
+    """Before the fix this returned 3: BRENNER, CARLOW, JACKSON."""
+    result = names(LD_1817)
+    assert len(result) == 25
+    assert result[0] == "BRENNER"  # presenter stays first
+    for expected in ("BAILEY", "BALDACCI", "LYFORD", "KEIM", "CURRY"):
+        assert expected in result
+
+
+def test_house_roster_list_yields_every_cosponsor():
+    result = names(LD_2007)
+    assert len(result) == 25
+    for expected in ("ABDI", "EATON", "CROCKETT", "BABIN"):
+        assert expected in result
+
+
+# --- chamber comes from the plural label ---
+
+
+def test_bare_names_take_the_chamber_of_their_label():
+    by_name = mentions(LD_1817)
+    assert by_name["BAILEY"] == "Senate"
+    assert by_name["LYFORD"] == "Senate"
+    assert by_name["CARLOW"] == "House"  # own title, outside the roster list
+
+
+def test_house_label_assigns_house():
+    by_name = mentions(LD_2007)
+    assert by_name["ABDI"] == "House"
+    assert by_name["DHALAC"] == "House"
+
+
+def test_individual_title_inside_a_list_wins_over_the_label():
+    """President JACKSON sits inside "Senators:" and is a senator either way."""
+    assert mentions(LD_1817)["JACKSON"] == "Senate"
+
+
+def test_both_labels_in_one_block_split_correctly():
+    text = (
+        "Presented by Senator BRENNER of Cumberland.\n"
+        "Cosponsored by Senators: BAILEY of York, CURRY of Waldo, "
+        "Representatives: ABDI of Lewiston, BOYLE of Gorham.\n"
+        "Be it enacted by the People of the State of Maine as follows:\n"
+    )
+    by_name = mentions(text)
+    assert by_name["BAILEY"] == "Senate"
+    assert by_name["CURRY"] == "Senate"
+    assert by_name["ABDI"] == "House"
+    assert by_name["BOYLE"] == "House"
+
+
+# --- name shapes that appear in real rosters ---
+
+
+def test_hyphenated_and_mixed_case_surnames_survive():
+    result = names(LD_1817)
+    assert "BEEBE-CENTER" in result
+    assert "LaFOUNTAIN" in result
+
+
+def test_two_word_surname_in_a_roster_list():
+    text = (
+        "Presented by Senator BRENNER of Cumberland.\n"
+        "Cosponsored by Representatives: TALBOT ROSS of Portland, ABDI of Lewiston.\n"
+        "Be it enacted by the People of the State of Maine as follows:\n"
+    )
+    assert "TALBOT ROSS" in names(text)
+
+
+def test_tribal_representative_locality():
+    assert "DANA" in names(LD_2007)
+
+
+# --- the garbage that got the old sweep removed ---
+
+
+def test_body_text_after_the_block_is_not_swept():
+    text = LD_1817 + (
+        "Sec. 1.  5 MRSA is amended to read: the Town of Brunswick and the "
+        "University of Maine and Senator SOMEONE of Nowhere shall confer.\n"
+    )
+    result = names(text)
+    assert "SOMEONE" not in result
+    assert "Brunswick" not in result
+    assert "University" not in result
+
+
+def test_a_block_with_no_roster_label_is_unchanged():
+    """The common case: a few cosponsors, each with its own title."""
+    text = (
+        "Presented by Senator DAUGHTRY of Cumberland.\n"
+        "Cosponsored by Representative PERRY of Calais and "
+        "Senator PERRY of Bangor.\n"
+        "Be it enacted by the People of the State of Maine as follows:\n"
+    )
+    assert TextExtractor._extract_sponsor_mentions(text) == [
+        ("DAUGHTRY", "Senate"),
+        ("PERRY", "House"),
+        ("PERRY", "Senate"),
+    ]
+
+
+def test_locality_is_required_for_a_roster_entry():
+    """Without " of <place>" an entry is prose, not a sponsor."""
+    text = (
+        "Presented by Senator BRENNER of Cumberland.\n"
+        "Cosponsored by Senators: BAILEY of York, And Other Things Happened.\n"
+        "Be it enacted by the People of the State of Maine as follows:\n"
+    )
+    result = names(text)
+    assert "BAILEY" in result
+    assert not any(n.startswith("And") for n in result)
+
+
+# --- the window, which truncated long lists on its own ---
+
+
+def test_long_roster_survives_the_search_window():
+    """A 99-cosponsor block runs past the old 2,500-character window.
+
+    Entry lengths matter here, so they are kept realistic — Maine entries
+    average about 30 characters ("BEEBE-CENTER of Knox, ",
+    "DANA of the Passamaquoddy Tribe, "). At 2,500 this fixture yields 65 of
+    100; the shortened localities an earlier draft used fit inside the old
+    window and quietly tested nothing.
+    """
+    surnames = [f"MEMBER{chr(65 + i // 26)}{chr(65 + i % 26)}" for i in range(99)]
+    entries = ", ".join(f"{s} of South Cumberland Falls" for s in surnames)
+    text = (
+        "Legislative Document\nNo. 2007\nH.P. 1289\n"
+        "House of Representatives, June 12, 2023\n"
+        "An Act to Make Sure That Everything Is Properly Considered\n"
+        "Presented by Speaker TALBOT ROSS of Portland.\n"
+        f"Cosponsored by Representatives: {entries}.\n"
+        "Be it enacted by the People of the State of Maine as follows:\n"
+    )
+    assert len(text) > 3500, "fixture must exceed the old window to be a guard"
+
+    result = names(text)
+    assert surnames[0] in result
+    assert surnames[-1] in result, "tail of a long roster was truncated"
+    assert len(result) == 100
+
+
+def test_dedup_still_collapses_a_repeated_name():
+    text = (
+        "Presented by Senator BAILEY of York.\n"
+        "Cosponsored by Senators: BAILEY of York, CURRY of Waldo.\n"
+        "Be it enacted by the People of the State of Maine as follows:\n"
+    )
+    assert names(text) == ["BAILEY", "CURRY"]

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -599,3 +599,70 @@ def test_the_longer_ceiling_is_gated_on_the_article():
     ):
         text = f"Cosponsored by Senators: BAILEY of York, {clause}\n"
         assert names(text) == ["BAILEY"], clause
+
+
+# --- round 5: the prefix stop must survive a rejected name ---
+
+
+def test_a_rejected_name_on_a_prose_cell_still_stops_the_run():
+    """Ordering the guard rejection before the prefix-stop skipped that stop, so
+    a rejected name on a cell with prose behind it let the run continue into
+    body text — exactly what the stop exists to prevent. Zero occurrences in 271
+    real bills, but the docstring claimed prose is never read."""
+    text = (
+        "Presented by Senator BAILEY of York.\n"
+        "Cosponsored by Senators: DAUGHTRY of Cumberland, COUNTY of Cumberland. "
+        "Notwithstanding any other provision of law, MDOT of Augusta, "
+        "GROHOSKI of Hancock.\nBe it enacted:\n"
+    )
+    assert names(text) == ["BAILEY", "DAUGHTRY"]
+
+
+def test_a_rejected_name_on_a_clean_cell_still_skips_rather_than_stops():
+    """The other half: the non-cascading skip must survive the fix above."""
+    text = (
+        "Cosponsored by Senators: BAILEY of York, COUNTY of Cumberland, "
+        "CURRY of Waldo.\nBe it enacted:\n"
+    )
+    assert names(text) == ["BAILEY", "CURRY"]
+
+
+# --- guards the round-5 mutation pass found unconstrained ---
+
+
+def test_the_label_requires_its_colon():
+    """ "Senators" without a colon is prose, not a roster opener. Real rosters
+    always carry it; dropping the requirement lets a bare plural in running
+    text open a segment."""
+    text = (
+        "Cosponsored by Senator BAILEY of York and the Senators "
+        "MARTIN of Eagle Lake, GRANT of Gardiner.\n"
+    )
+    assert names(text) == ["BAILEY"]
+
+
+def test_the_label_is_word_bounded():
+    """Without \\b the label matches as a substring and opens a bogus segment."""
+    text = (
+        "Cosponsored by Senator BAILEY of York. "
+        "CoSenators: MARTIN of Eagle Lake, GRANT of Gardiner.\n"
+    )
+    assert names(text) == ["BAILEY"]
+
+
+def test_an_individual_title_inside_a_roster_keeps_its_own_chamber():
+    """A Speaker listed inside a "Senators:" run is still House.
+
+    Note this is NOT isolating _ROSTER_ENTRY's title group: the title-adjoining
+    patterns match "Speaker FECTEAU of Biddeford" independently, so the chamber
+    is right either way and neutering the group changes nothing observable.
+    Kept as a behavioural assertion, not claimed as a guard test.
+    """
+    text = (
+        "Cosponsored by Senators: BAILEY of York, Speaker FECTEAU of Biddeford, "
+        "CURRY of Waldo.\nBe it enacted:\n"
+    )
+    by_name = mentions(text)
+    assert by_name["BAILEY"] == "Senate"
+    assert by_name["FECTEAU"] == "House"
+    assert by_name["CURRY"] == "Senate"

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -471,12 +471,22 @@ def test_a_short_clause_that_reads_as_a_locality_is_not_separable():
     is shape-identical to a long locality. The boundary closes clauses that run
     LONGER than a locality; it cannot close ones that do not.
 
-    Bounded: at most one bogus name per roster segment, only when the block is
-    unterminated, and enrichment publishes it with a null id and null
-    confidence rather than a guessed identity.
+    NOT bounded to one per segment — an earlier version of this docstring
+    claimed that and it was false. A fully-consumed bogus cell leaves
+    ``match.end() == len(cell)``, so the run CONTINUES and the next such cell is
+    read too. What actually bounds it is that every cell in the run must keep
+    fitting the shape, and that enrichment publishes an unmatched name with a
+    null id and null confidence rather than a guessed identity.
     """
     text = "Cosponsored by Senators: BAILEY of York, USDA of Washington provides the funds.\n"
     assert names(text) == ["BAILEY", "USDA"]
+
+    # Three, not one — the case the old docstring said could not happen.
+    run_on = (
+        "Cosponsored by Senators: BAILEY of York, DHHS of Augusta shall report, "
+        "DOE of Portland shall assist, EPA of Maine is repealed.\n"
+    )
+    assert names(run_on) == ["BAILEY", "DHHS", "DOE", "EPA"]
 
 
 def test_abbreviated_place_names_survive_the_sentence_boundary():
@@ -488,3 +498,104 @@ def test_abbreviated_place_names_survive_the_sentence_boundary():
         "Be it enacted:\n"
     )
     assert names(text) == ["SMYTH", "PIERCE", "JONES", "DANA"]
+
+
+# --- round 4: losses measured against 296 real bills, sessions 125-132 ---
+
+
+def test_a_singular_trailing_chamber_label_opens_a_segment():
+    """Maine routinely closes a roster with a one-member label. Matching only
+    the plural cost that entry AND terminated the run before it, since
+    "Representative: STUCKEY of Portland" is not a well-formed cell. Largest
+    single loss class in the corpus: 55 of 68 affected bills."""
+    text = (
+        "Cosponsored by Senators: FARNSWORTH of Cumberland, ALFOND of Cumberland, "
+        "Representative: STUCKEY of Portland.\nBe it enacted:\n"
+    )
+    assert names(text) == ["FARNSWORTH", "ALFOND", "STUCKEY"]
+
+
+def test_the_singular_label_still_carries_its_chamber():
+    text = (
+        "Cosponsored by Representatives: BERRY of Bowdoinham, "
+        "Senator: BLACK of Franklin.\nBe it enacted:\n"
+    )
+    by_name = mentions(text)
+    assert by_name["BERRY"] == "House"
+    assert by_name["BLACK"] == "Senate"
+
+
+def test_a_denylisted_name_does_not_take_the_rest_of_the_roster_with_it():
+    """Session 129 HP0037, real text. "HALL of Wilton" is a real legislator who
+    collides with the denylist; ending the run on a rejection took HICKMAN,
+    INGWERSEN, MAXMIN, O'NEIL and BLACK down with him — six lost from one
+    collision. A rejection skips the cell now; only a cell that is not an entry
+    at all, or one with prose behind it, ends the run."""
+    text = (
+        "Cosponsored by Representatives: BERRY of Bowdoinham, DUNPHY of Old Town, "
+        "HALL of Wilton, HICKMAN of Winthrop, INGWERSEN of Arundel, "
+        "MAXMIN of Nobleboro, O'NEIL of Saco, Senator: BLACK of Franklin.\n"
+        "Be it enacted:\n"
+    )
+    assert names(text) == [
+        "BERRY",
+        "DUNPHY",
+        "HALL",
+        "HICKMAN",
+        "INGWERSEN",
+        "MAXMIN",
+        "O'NEIL",
+        "BLACK",
+    ]
+
+
+def test_hall_is_a_surname_on_the_roster_path():
+    """The denylist exists for the title-adjoining patterns, where "Hall" is
+    "City Hall". Inside a chamber-anchored roster it is positionally a surname.
+    This only became reachable when the denylist was case-folded."""
+    text = "Cosponsored by Senators: HALL of Wilton, BAILEY of York.\nBe it enacted:\n"
+    assert names(text) == ["HALL", "BAILEY"]
+
+
+def test_a_denylisted_noun_is_still_dropped_just_not_cascading():
+    text = (
+        "Cosponsored by Senators: BAILEY of York, COUNTY of Cumberland, "
+        "CURRY of Waldo.\nBe it enacted:\n"
+    )
+    assert names(text) == ["BAILEY", "CURRY"]
+
+
+def test_tribal_designations_exceed_the_ordinary_locality_ceiling():
+    """Session 127 HP0013, real text. "of the Houlton Band of Maliseet Indians"
+    is five words; at a four-word ceiling the cell failed, and because it sorts
+    first alphabetically the whole roster died — 0 of 8. The Maliseet seat was
+    refilled in May 2025, so this is session 132 and in scope."""
+    text = (
+        "Cosponsored by Senator DILL of Penobscot and Representatives: "
+        "BEAR of the Houlton Band of Maliseet Indians, BECK of Waterville, "
+        "DANA of the Passamaquoddy Tribe, DION of Portland, MARTIN of Eagle Lake, "
+        "ROTUNDO of Lewiston, SCHNECK of Bangor.\nBe it enacted:\n"
+    )
+    assert names(text) == [
+        "DILL",
+        "BEAR",
+        "BECK",
+        "DANA",
+        "DION",
+        "MARTIN",
+        "ROTUNDO",
+        "SCHNECK",
+    ]
+
+
+def test_the_longer_ceiling_is_gated_on_the_article():
+    """The extra room is for "of THE <tribal designation>", which is what the
+    long real localities look like. Ungated it re-accepts the clause class —
+    "of Augusta shall study the matter" is five words too."""
+    for clause in (
+        "MDOT of Augusta shall study the matter.",
+        "MRSA of Title 5 is amended to read as follows.",
+        "PART A of Chapter 12 takes effect on July 1.",
+    ):
+        text = f"Cosponsored by Senators: BAILEY of York, {clause}\n"
+        assert names(text) == ["BAILEY"], clause

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -208,3 +208,81 @@ def test_dedup_still_collapses_a_repeated_name():
         "Be it enacted by the People of the State of Maine as follows:\n"
     )
     assert names(text) == ["BAILEY", "CURRY"]
+
+
+# --- the sweep must not depend on the terminator list being exhaustive ---
+#
+# Review finding on #16: anchoring to the plural label is not by itself what
+# bounds the sweep — the block terminators are, and they are a denylist with
+# reachable gaps. `is_valid_name` is a 34-word denylist that omits City,
+# Village, Board, University, Nation, Region: the vocabulary of bill body text.
+
+
+def test_amendment_body_is_not_swept_for_sponsors():
+    """Amendments open "Amend the bill", which no terminator matched, so the
+    block ran the full window into body text. ~45% of a session's documents."""
+    text = (
+        "Presented by Representative ABDI of Lewiston.\n"
+        "Cosponsored by Representatives: BOYLE of Gorham, CRAVEN of Lewiston.\n"
+        "Amend the bill in section 1 by inserting: This applies to the "
+        "City of Portland, Village of Kingfield, and the Board of Trustees of "
+        "the University of Maine System.\n"
+    )
+    assert names(text) == ["ABDI", "BOYLE", "CRAVEN"]
+
+
+def test_uppercase_resolved_terminates_the_block():
+    """Resolutions print RESOLVED:; the terminator was case-sensitive."""
+    text = (
+        "Presented by Senator BRENNER of Cumberland.\n"
+        "Cosponsored by Senators: BAILEY of York, CURRY of Waldo.\n"
+        "RESOLVED: That we recognize the Penobscot Nation of Indian Island "
+        "and the City of Bangor.\n"
+    )
+    assert names(text) == ["BRENNER", "BAILEY", "CURRY"]
+
+
+def test_title_case_nouns_are_rejected_even_in_an_unterminated_block():
+    """The guard that actually holds: rosters print surnames in capitals, and
+    every false positive is Title Case. This block never terminates at all."""
+    filler = "The department shall consider each application on its merits. " * 60
+    text = (
+        "Presented by Senator BRENNER of Cumberland.\n"
+        "Cosponsored by Senators: BAILEY of York.\n"
+        + filler
+        + "reports from the Region of Downeast Maine, the Coalition of Towns, "
+        "and the Friends of Acadia.\n"
+    )
+    assert names(text) == ["BRENNER", "BAILEY"]
+
+
+def test_a_stray_plural_label_in_body_text_opens_no_segment_of_substance():
+    text = (
+        "Presented by Senator BRENNER of Cumberland.\n"
+        "Cosponsored by Senators: BAILEY of York.\n"
+        "Amend the bill by inserting: the panel consists of the following "
+        "Representatives: Jane of Portland, John of Bangor.\n"
+    )
+    assert names(text) == ["BRENNER", "BAILEY"]
+
+
+def test_all_real_surname_shapes_survive_the_capitals_guard():
+    """Guard must not cost legitimate names: hyphenated, mixed-case, two-word,
+    and leadership titles inside a list."""
+    text = (
+        "Presented by Senator BRENNER of Cumberland.\n"
+        "Cosponsored by Senators: BEEBE-CENTER of Knox, LaFOUNTAIN of Kennebec, "
+        "President JACKSON of Aroostook, "
+        "Representatives: TALBOT ROSS of Portland, DHALAC of South Portland, "
+        "DANA of the Passamaquoddy Tribe.\n"
+        "Be it enacted by the People of the State of Maine as follows:\n"
+    )
+    assert names(text) == [
+        "BRENNER",
+        "JACKSON",
+        "BEEBE-CENTER",
+        "LaFOUNTAIN",
+        "TALBOT ROSS",
+        "DHALAC",
+        "DANA",
+    ]

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -286,3 +286,93 @@ def test_all_real_surname_shapes_survive_the_capitals_guard():
         "DHALAC",
         "DANA",
     ]
+
+
+# --- second review round: bounding the sweep positively ---
+#
+# The reviewer's point was that anchoring to the plural label does not bound the
+# sweep; only the terminators do, and those are a denylist with reachable gaps.
+# The fix is to make the roster a bounded positive parse: a contiguous
+# comma-delimited run of "NAME of LOCALITY" cells, ended by the first cell that
+# is not one.
+
+
+def test_an_amendment_directive_terminates_the_block():
+    """Amendments open "Amend the bill/resolve/amendment by", which was not in
+    the terminator list -- so on an amendment the block ran to the window edge."""
+    for directive in ("Amend the bill", "Amend the resolve", "Amend the amendment"):
+        text = (
+            "Cosponsored by Representatives: ABDI of Lewiston, BOYLE of Gorham.\n"
+            f"{directive} by inserting after section 1 the following: "
+            "the LURC of Augusta shall report.\n"
+        )
+        assert names(text) == ["ABDI", "BOYLE"], directive
+
+
+def test_a_lettered_section_terminates_the_block():
+    """Terminator was Sec.\\s*\\d, so the lettered form "Sec. A-1" slipped past."""
+    text = (
+        "Cosponsored by Senators: BRENNER of Cumberland, BAILEY of York.\n"
+        "Sec. A-1. 5 MRSA 12004 is amended. The Board of Trustees of Orono "
+        "and the Council of Elders of Indian Township shall meet.\n"
+    )
+    assert names(text) == ["BRENNER", "BAILEY"]
+
+
+def test_a_prose_cosponsored_by_does_not_open_a_block():
+    """Case-insensitivity belongs on the terminators, not the opener. Applied to
+    the whole pattern it let a lowercase "cosponsored by" inside the window open
+    a block where the bill had none."""
+    text = (
+        "Be it enacted by the People of the State of Maine as follows:\n"
+        "The report shall list each measure cosponsored by Senators: "
+        "BRENNER of Cumberland, GRANT of Gardiner.\n"
+    )
+    assert names(text) == []
+
+
+def test_a_cell_that_is_not_a_clean_entry_ends_the_roster():
+    """Skipping bad cells (continue) let body text far past the end of the
+    roster still be harvested, because prose always intervenes and was simply
+    stepped over. The first bad cell must end the run."""
+    text = (
+        "Cosponsored by Senators: BAILEY of York, CURRY of Waldo, "
+        "and the department shall report to the joint standing committee, "
+        "MARTIN of Eagle Lake.\n"
+    )
+    assert names(text) == ["BAILEY", "CURRY"]
+    assert "MARTIN" not in names(text)
+
+
+def test_a_long_roster_is_not_truncated_by_the_entry_guard():
+    """The guard must not cost a widely cosponsored bill its list -- recovering
+    those was the entire point of the change."""
+    roster = ", ".join(f"NAME{c} of Town" for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+    # Real rosters print surnames in capitals with no digits; this stands in for
+    # a 26-name list without inventing 26 plausible Maine surnames.
+    roster = roster.replace("NAME", "SMYTH").replace("0", "")
+    text = f"Cosponsored by Senators: {roster}.\nBe it enacted:\n"
+    assert len(names(text)) == 26
+
+
+def test_an_agency_acronym_inside_the_roster_run_is_not_separable_by_shape():
+    """Known limit, recorded deliberately rather than papered over.
+
+    "DHHS of Augusta" is grammatically identical to "BAILEY of York" -- same
+    capitals, same "of LOCALITY". No shape test can separate them, so a cell
+    like this, appearing *inside* an unterminated roster run, is read as a name.
+
+    What bounds it in practice is that real bill text following a roster starts
+    with a terminator (the enacting clause, a preamble, a section, an amendment
+    directive), and the sweep stops there. The corpus audit
+    (scripts/audit_roster_sweep.py) measures whether that holds.
+
+    The downstream defence is enrichment: an unmatched name publishes with a
+    null sponsor_id and null confidence rather than a guessed identity, so a
+    stray acronym is visible in the data rather than silently wrong.
+    """
+    text = (
+        "Cosponsored by Senators: BAILEY of York, DHHS of Augusta.\n"
+        "Be it enacted by the People of the State of Maine as follows:\n"
+    )
+    assert names(text) == ["BAILEY", "DHHS"]

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -376,3 +376,115 @@ def test_an_agency_acronym_inside_the_roster_run_is_not_separable_by_shape():
         "Be it enacted by the People of the State of Maine as follows:\n"
     )
     assert names(text) == ["BAILEY", "DHHS"]
+
+
+# --- round 3: each guard isolated, so removing it turns a test red ---
+#
+# The tests above were written to lock in specific guards and did not: the
+# prefix-parse change subsumed them, so deleting the capitals guard, the
+# `Amend the ...` terminator, the lettered-section terminator, or the
+# prefix-branch stop left the whole suite green. Each fixture below is built so
+# that ONE guard is the only thing between the parser and a bad capture.
+
+
+def test_the_capitals_guard_is_load_bearing():
+    """Isolates _ROSTER_SURNAME.
+
+    The noun has to be Title Case (so the capitals guard is what rejects it) and
+    NOT on the denylist (so is_valid_name is not what rejects it) -- otherwise
+    the fixture passes with the capitals guard deleted and proves nothing.
+    """
+    text = (
+        "Cosponsored by Senators: BAILEY of York, Meadow of Islesboro, Harbor of Cutler.\n"
+        "The department shall consider each application on its merits.\n"
+    )
+    assert names(text) == ["BAILEY"]
+
+
+def test_the_denylist_is_load_bearing_in_capitals():
+    """Isolates is_valid_name on the roster path, which is ALL CAPS by
+    construction. The list is written in Title Case and was compared
+    case-sensitively, so every word on it passed in capitals -- COUNTY,
+    DEPARTMENT, SENATE and LEGISLATURE were all reachable as "sponsors" while
+    the list that names them looked like it was doing the work."""
+    for noun in ("COUNTY", "DEPARTMENT", "SENATE", "LEGISLATURE", "CITY", "UNIVERSITY"):
+        text = f"Cosponsored by Senators: BAILEY of York, {noun} of Cumberland.\nBe it enacted:\n"
+        assert names(text) == ["BAILEY"], noun
+
+
+def test_the_amend_terminator_is_load_bearing():
+    """Isolates `Amend the (bill|resolve|amendment)`.
+
+    The bad text has to sit behind a SECOND plural label. _roster_segments
+    splits the block on those labels and each segment starts a fresh run, so a
+    label after the directive is reachable even though the prose before it
+    would have stopped the first run. Without the terminator the block extends
+    to include that second label; with it, the block is cut first.
+    """
+    for directive in ("Amend the bill", "Amend the resolve", "Amend the amendment"):
+        text = (
+            f"Cosponsored by Representatives: ABDI of Lewiston, BOYLE of Gorham. "
+            f"{directive} by adding, Senators: MARTIN of Eagle Lake, GRANT of Gardiner.\n"
+        )
+        assert names(text) == ["ABDI", "BOYLE"], directive
+
+
+def test_the_lettered_section_terminator_is_load_bearing():
+    """Isolates `Sec.\\s*[A-Za-z0-9]`; same construction as above, since the
+    digits-only form let the block run past `Sec. A-1` into the body."""
+    text = (
+        "Cosponsored by Senators: BRENNER of Cumberland, BAILEY of York. "
+        "Sec. A-1. 5 MRSA 12004 is amended by adding, "
+        "Representatives: MARTIN of Eagle Lake, GRANT of Gardiner.\n"
+    )
+    assert names(text) == ["BRENNER", "BAILEY"]
+
+
+def test_the_prefix_branch_stops_the_run():
+    """Isolates the `return` after a partially-consumed cell. With `continue`
+    the run steps over the prose and keeps harvesting the cells behind it."""
+    text = (
+        "Cosponsored by Senators: BAILEY of York. The department shall report, "
+        "MARTIN of Eagle Lake, GRANT of Gardiner.\n"
+    )
+    assert names(text) == ["BAILEY"]
+
+
+def test_a_locality_must_end_the_cell_not_run_into_a_clause():
+    """A roster cell is a noun phrase; "MDOT of Augusta shall study the matter"
+    is a clause. Both fit the four-word ceiling, so the sentence boundary is
+    what separates them."""
+    for clause in (
+        "MDOT of Augusta shall study the matter.",
+        "MRSA of Title 5 is amended to read as follows.",
+        "PART A of Chapter 12 takes effect on July 1.",
+    ):
+        text = f"Cosponsored by Senators: BAILEY of York, {clause}\n"
+        assert names(text) == ["BAILEY"], clause
+
+
+def test_a_short_clause_that_reads_as_a_locality_is_not_separable():
+    """The other half of the known limit, recorded rather than asserted away.
+
+    "USDA of Washington provides the funds." is a clause, but "Washington
+    provides the funds" fits the four-word ceiling and ends in a period, so it
+    is shape-identical to a long locality. The boundary closes clauses that run
+    LONGER than a locality; it cannot close ones that do not.
+
+    Bounded: at most one bogus name per roster segment, only when the block is
+    unterminated, and enrichment publishes it with a null id and null
+    confidence rather than a guessed identity.
+    """
+    text = "Cosponsored by Senators: BAILEY of York, USDA of Washington provides the funds.\n"
+    assert names(text) == ["BAILEY", "USDA"]
+
+
+def test_abbreviated_place_names_survive_the_sentence_boundary():
+    """The period in "St. Albans" must not read as the end of the cell, or the
+    roster stops one town early."""
+    text = (
+        "Cosponsored by Senators: SMYTH of St. Albans, PIERCE of St. George, "
+        "JONES of Isle au Haut, DANA of the Passamaquoddy Tribe.\n"
+        "Be it enacted:\n"
+    )
+    assert names(text) == ["SMYTH", "PIERCE", "JONES", "DANA"]


### PR DESCRIPTION
Answers issue #13 item 4 — and the answer is not what that item says. It's a regression from February, and it's the reason session 132 looked anomalous.

## What the data actually shows

The diagnostic added in #15 refuted item 4's hypothesis. Sessions 132 and 131 are within half a point of each other on every failure measure:

| | 132 | 131 |
|---|---|---|
| amendment share | 45% | 44% |
| originals with no sponsors | 4.2% | 4.5% |
| recoverable by re-extraction | **0** | **0** |

Extraction is not failing per bill. But sampling bills that *do* have sponsors — which the original diagnostic never did — found this:

| bill | stored sponsors | current extractor finds |
|---|---|---|
| 131-LD-1817 | **96** | **3** |
| 131-LD-2007 | **99** | **2** |
| 132-LD-2196 | 4 | 4 |

Widely cosponsored bills name the chamber once and then list bare surnames:

```
Cosponsored by Representative CARLOW of Buxton and
Senators: BAILEY of York, BALDACCI of Penobscot, BEEBE-CENTER of Knox,
BENNETT of Oxford, ... President JACKSON of Aroostook, ...
```

Every pattern needs a title adjoining the name, so only the handful carrying their own — President, Speaker — get collected. On a 99-cosponsor bill that is 2 of 99.

**Session 131 was scraped before the regression and carries full lists; 132 was scraped after and does not.** That is the entire 1.48-vs-5.03 mentions/doc gap. Worth being blunt about the direction: a re-scrape today would have degraded 131 to match 132, not lifted 132 to match 131.

## Two independent causes

**1. No bare-name handling.** A sweep existed until `300cd207` (Feb 18), removed for producing garbage — it matched any `Capitalized of Somewhere` anywhere in the block:

```python
cleaned_block = re.sub(r'\b(?:Senator|Representative|...)\s+[A-Z]...', '', cosp_block)
comma_separated = re.findall(r'([A-Z][A-Za-z\'\-]+...)\s+of\s+[A-Za-z\s]+', cleaned_block)
```

That removal was right; reverting it would be wrong. The replacement is **anchored to the plural label** instead — names are read only inside a segment opened by `Senators:`/`Representatives:`, and only when followed by ` of <locality>`. That bounds the search *and* supplies the chamber, so these entries come out better identified than the ones the old sweep produced. There's a test asserting `Town of Brunswick`, `University of Maine`, and a `Senator SOMEONE of Nowhere` in body text stay out.

**2. The 2,500-character search window,** which truncated long lists on its own. With realistic entry lengths (Maine entries average ~30 chars: `BEEBE-CENTER of Knox, `, `DANA of the Passamaquoddy Tribe, `) a 100-cosponsor bill yielded **65**. Raised to 8,000, and the cosponsor block now terminates on `Be it enacted` / `Emergency preamble` / `Preamble.` / `Resolved:` / `SUMMARY` / `Sec. N` — so widening it can't let the title-adjoining patterns reach into the bill body.

## Verified on real records

`132-LD-2196` stores 4 and now yields 7, recovering MEYER, MOONEN and BAILEY:

```
GATTINE      House      INGWERSEN    Senate     FECTEAU      House
DAUGHTRY     Senate     MEYER        House      MOONEN       House
BAILEY       Senate
```

Chambers come from the labels, and an individual title inside a list still wins over its label.

## Tier-2 review notes

- **Tier decision:** Tier-2. `text_extractor.py`, tests, and `CLAUDE.md` only — no schema field changes, no publish path, no `.github/`, no dependencies, no secrets. It *does* change extraction output, which reaches the dataset on the next scrape; that's a data-quality fix, not a schema change, but it's the thing worth a reviewer's attention.
- **Risk:** more sponsors per bill on re-scrape — the point of the change, and it moves counts. The failure mode to watch is over-capture inside roster segments; the locality requirement and the block terminators are what bound it, and both are tested. `sponsor_chambers` alignment is unaffected since mentions stay ordered and deduped as before.
- **Checks:** 14 new tests built from the two worst real blocks; 358 passing, ruff clean. Each fix was verified to be load-bearing — the window test failed at 2,500 (65 of 100) and passes at 8,000, and an earlier draft of that fixture was rejected for being 2,260 chars and therefore testing nothing.
- **Rollback:** revert the commit. Nothing published; the dataset is unchanged until the next scrape.

## Follow-on, not in this PR

- Issue #13 item 4 needs rewriting — I'll update it.
- The published v1 data is internally inconsistent (131 full lists, 132 truncated). Fixing it needs a re-scrape of at least 132, or an enrichment pass that re-extracts from the published `text`, which is possible since the sponsor block survives into that column.
- Gate A's 132 rate of 98.2% is computed over the truncated denominator and should be re-read after that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WicqsC1r64bRg1pbAqFsTV)_