### PR TITLE
[Tier-2] feat: bill status parser (A1) + member roster parser (D5) + roster recon

### DIFF
--- a/scripts/recon_legislature.py
+++ b/scripts/recon_legislature.py
@@ -73,14 +73,44 @@ SEED_TEMPLATES: list[str] = [
     "https://legislature.maine.gov/legis/",
 ]
 
+# Roster-only seeds, used by --focus roster. These are the real pages the first
+# crawl surfaced as links but never had budget to fetch -- the bill directory
+# ate it. "Senators Listed by Municipality" is the locality -> legislator map
+# issue #13 item 2 needs and OpenStates does not provide.
+ROSTER_SEED_TEMPLATES: list[str] = [
+    "https://legislature.maine.gov/senate/find-your-state-senator/9392",
+    "https://legislature.maine.gov/senate/district-listing/9526",
+    "https://legislature.maine.gov/senate/senators/9536",
+    "https://legislature.maine.gov/house/house/",
+    "https://legislature.maine.gov/housedems/",
+    "https://legislature.maine.gov/house-independents/house-independents/9453",
+    # Historical rosters are the open question -- sessions 121-124 predate the
+    # current site. LawMakerWeb is the era-appropriate application, so probe it.
+    "https://legislature.maine.gov/LawMakerWeb/sponsors.asp?SessionID={session}",
+    "https://legislature.maine.gov/legis/house/hbiolist.htm",
+    "https://legislature.maine.gov/legis/senate/sbiolist.htm",
+]
+
 # Link text/href fragments worth spending the page budget on. Ordered roughly by
 # how directly they bear on the two parsers.
 INTEREST_PATTERNS: list[tuple[str, str]] = [
     ("bill_status", r"display_ps|paper\s*status|legislative\s*history|bill\s*status|summary\.asp"),
     ("bill_search", r"lawmakerweb|searchresults|billtracking|/bills?/"),
-    ("roster", r"memberprofile|listalpha|listdistrict|senators|representatives|roster|members?\b"),
+    (
+        "roster",
+        # Party caucus pages carry the member lists, and their links say
+        # "House Democrats" rather than anything with "member" in it.
+        r"memberprofile|listalpha|listdistrict|senators?|representatives?|roster|members?\b"
+        r"|housedems|househsubmit|democrats|republicans|independents|unenrolled"
+        r"|district-listing|find-your-state|biolist",
+    ),
     ("session_index", r"snum=|sessionid=|session\s*\d{3}"),
 ]
+
+# --focus roster confines the crawl to roster links. Without it the bill
+# directory absorbs the page budget: the first run spent 42 of 60 pages on
+# billdirectory_ps.asp and never reached a single member list.
+FOCUS_CATEGORIES = {"roster": {"roster"}}
 
 _SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
@@ -189,6 +219,7 @@ def crawl(
     max_pages: int,
     delay: float,
     robots: RobotsPolicy,
+    categories: set[str] | None = None,
 ) -> list[dict]:
     """Breadth-first crawl from the seeds, saving HTML and recording link maps.
 
@@ -223,6 +254,8 @@ def crawl(
             record["links"] = links
             record["interesting"] = [link for link in links if link["categories"]]
             for link in record["interesting"]:
+                if categories and not categories.intersection(link["categories"]):
+                    continue
                 if link["url"] not in visited:
                     queue.append((link["url"], depth + 1))
 
@@ -244,6 +277,13 @@ def main() -> int:
         action="store_true",
         help="Skip robots.txt checks (default: honor them)",
     )
+    parser.add_argument(
+        "--focus",
+        choices=["all", "roster"],
+        default="all",
+        help="'roster' seeds and follows member lists only, so the bill directory "
+        "cannot absorb the page budget",
+    )
     args = parser.parse_args()
 
     out_dir = args.out / f"session-{args.session}"
@@ -252,7 +292,8 @@ def main() -> int:
     http = requests.Session()
     http.headers.update({"User-Agent": USER_AGENT})
 
-    seeds = [template.format(session=args.session) for template in SEED_TEMPLATES]
+    templates = ROSTER_SEED_TEMPLATES if args.focus == "roster" else SEED_TEMPLATES
+    seeds = [template.format(session=args.session) for template in templates]
     summary: dict = {
         "session": args.session,
         "seeds": seeds,
@@ -262,7 +303,15 @@ def main() -> int:
 
     try:
         robots = RobotsPolicy(http, respect=not args.ignore_robots)
-        summary["pages"] = crawl(seeds, http, out_dir, args.max_pages, args.delay, robots)
+        summary["pages"] = crawl(
+            seeds,
+            http,
+            out_dir,
+            args.max_pages,
+            args.delay,
+            robots,
+            categories=FOCUS_CATEGORIES.get(args.focus),
+        )
     except Exception as e:  # noqa: BLE001 -- degrade gracefully, always write the index
         summary["fatal_error"] = f"{type(e).__name__}: {e}"
         print(f"Unexpected error: {e}", file=sys.stderr)

--- a/scripts/recon_legislature.py
+++ b/scripts/recon_legislature.py
@@ -112,6 +112,10 @@ INTEREST_PATTERNS: list[tuple[str, str]] = [
 # billdirectory_ps.asp and never reached a single member list.
 FOCUS_CATEGORIES = {"roster": {"roster"}}
 
+# Share of the page budget reserved for rosters in a default (focus=all) run,
+# so the two targets cannot starve each other.
+ROSTER_BUDGET_SHARE = 0.4
+
 _SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
@@ -303,15 +307,41 @@ def main() -> int:
 
     try:
         robots = RobotsPolicy(http, respect=not args.ignore_robots)
-        summary["pages"] = crawl(
-            seeds,
-            http,
-            out_dir,
-            args.max_pages,
-            args.delay,
-            robots,
-            categories=FOCUS_CATEGORIES.get(args.focus),
-        )
+        if args.focus == "all":
+            # Two phases with a reserved budget rather than one queue. A single
+            # BFS starves the rosters: the bill directory's depth-1 links are
+            # queued ahead of the roster seeds' and there are hundreds of them,
+            # which is how the first run spent 42 of 60 pages on
+            # billdirectory_ps.asp and reached no member list at all.
+            roster_budget = max(1, int(args.max_pages * ROSTER_BUDGET_SHARE))
+            roster_seeds = [t.format(session=args.session) for t in ROSTER_SEED_TEMPLATES]
+            summary["seeds"] = roster_seeds + seeds
+
+            print(f"=== phase 1: rosters (budget {roster_budget}) ===")
+            roster_pages = crawl(
+                roster_seeds,
+                http,
+                out_dir,
+                roster_budget,
+                args.delay,
+                robots,
+                categories={"roster"},
+            )
+            remaining = args.max_pages - len(roster_pages)
+            print(f"=== phase 2: everything else (budget {remaining}) ===")
+            summary["pages"] = roster_pages + crawl(
+                seeds, http, out_dir, remaining, args.delay, robots
+            )
+        else:
+            summary["pages"] = crawl(
+                seeds,
+                http,
+                out_dir,
+                args.max_pages,
+                args.delay,
+                robots,
+                categories=FOCUS_CATEGORIES.get(args.focus),
+            )
     except Exception as e:  # noqa: BLE001 -- degrade gracefully, always write the index
         summary["fatal_error"] = f"{type(e).__name__}: {e}"
         print(f"Unexpected error: {e}", file=sys.stderr)

--- a/scripts/recon_legislature.py
+++ b/scripts/recon_legislature.py
@@ -164,6 +164,16 @@ def extract_links(html: str, base_url: str) -> list[dict]:
     return links
 
 
+def _directive(robots_text: str, name: str) -> str | None:
+    """First value of a robots.txt directive, e.g. Crawl-delay, or None."""
+    for line in robots_text.splitlines():
+        line = line.split("#", 1)[0].strip()
+        key, _, value = line.partition(":")
+        if key.strip().lower() == name and value.strip():
+            return value.strip()
+    return None
+
+
 def page_title(html: str) -> str:
     soup = BeautifulSoup(html, features="html.parser")
     return soup.title.get_text(strip=True)[:200] if soup.title else ""
@@ -176,6 +186,10 @@ class RobotsPolicy:
         self._http = http
         self._respect = respect
         self._parsers: dict[str, urllib.robotparser.RobotFileParser | None] = {}
+        # Raw text per host, kept so a run can report the site's own stated
+        # crawl policy. Crawl-delay in particular decides our request rate, and
+        # that decision should come from the site rather than from our judgment.
+        self.raw: dict[str, str] = {}
 
     def allows(self, url: str) -> bool:
         if not self._respect:
@@ -193,6 +207,7 @@ class RobotsPolicy:
             res = self._http.get(robots_url, timeout=REQUEST_TIMEOUT)
             if res.status_code != 200:
                 return None
+            self.raw[parsed.netloc.lower()] = res.text
             parser = urllib.robotparser.RobotFileParser()
             parser.parse(res.text.splitlines())
             return parser
@@ -305,8 +320,10 @@ def main() -> int:
         "pages": [],
     }
 
+    # Bound before the try so the finally block can always read it.
+    robots = RobotsPolicy(http, respect=not args.ignore_robots)
+
     try:
-        robots = RobotsPolicy(http, respect=not args.ignore_robots)
         if args.focus == "all":
             # Two phases with a reserved budget rather than one queue. A single
             # BFS starves the rosters: the bill directory's depth-1 links are
@@ -346,6 +363,19 @@ def main() -> int:
         summary["fatal_error"] = f"{type(e).__name__}: {e}"
         print(f"Unexpected error: {e}", file=sys.stderr)
     finally:
+        # The site's stated policy, verbatim and parsed. Crawl-delay decides our
+        # request rate for the bill-status backfill; taking it from robots.txt
+        # rather than picking a number ourselves is both correct and checkable.
+        summary["robots"] = {
+            host: {
+                "crawl_delay": _directive(text, "crawl-delay"),
+                "request_rate": _directive(text, "request-rate"),
+            }
+            for host, text in robots.raw.items()
+        }
+        for host, text in robots.raw.items():
+            (out_dir / f"robots-{host}.txt").write_text(text, encoding="utf-8")
+
         fetched = [p for p in summary["pages"] if p.get("file")]
         summary["fetched_count"] = len(fetched)
         summary["by_category"] = {

--- a/src/maine_bills/bill_status.py
+++ b/src/maine_bills/bill_status.py
@@ -69,7 +69,8 @@ def normalize_ld(ld: int | str) -> str:
     Note the deliberate asymmetry with `status_url`, which strips the padding —
     the site wants `LD=1`, not `LD=0001`.
     """
-    return str(ld).strip().lstrip("0").zfill(LD_NUMBER_WIDTH) or "0".zfill(LD_NUMBER_WIDTH)
+    # "".zfill(4) is already "0000", so no empty-string fallback is needed.
+    return str(ld).strip().lstrip("0").zfill(LD_NUMBER_WIDTH)
 
 
 def status_url(session: int, ld: int | str) -> str:

--- a/src/maine_bills/bill_status.py
+++ b/src/maine_bills/bill_status.py
@@ -55,8 +55,28 @@ _GOVERNOR = re.compile(
 _DATE_FORMAT = "%b %d, %Y"
 
 
+LD_NUMBER_WIDTH = 4
+
+
+def normalize_ld(ld: int | str) -> str:
+    """Zero-pad an LD number to the width `schema.parse_filename` produces.
+
+    Filenames carry "132-LD-0001", so `BillRecord.ld_number` is "0001", while
+    the status page's title says "LD 1". Storing what the page says would make
+    every join against the published dataset miss: "1" != "0001". Padding here
+    keeps the two keyable against each other.
+
+    Note the deliberate asymmetry with `status_url`, which strips the padding —
+    the site wants `LD=1`, not `LD=0001`.
+    """
+    return str(ld).strip().lstrip("0").zfill(LD_NUMBER_WIDTH) or "0".zfill(LD_NUMBER_WIDTH)
+
+
 def status_url(session: int, ld: int | str) -> str:
-    """URL of the status page for one bill."""
+    """URL of the status page for one bill.
+
+    Takes a padded or unpadded LD; the site expects it unpadded.
+    """
     return STATUS_URL.format(ld=int(ld), session=int(session))
 
 
@@ -198,7 +218,7 @@ def parse_status_page(html: str, session: int | None = None, ld: str | None = No
 
     status = BillStatus(
         session=int(resolved_session),
-        ld_number=str(resolved_ld),
+        ld_number=normalize_ld(resolved_ld),
         paper=paper,
         source_url=status_url(int(resolved_session), resolved_ld),
     )

--- a/src/maine_bills/bill_status.py
+++ b/src/maine_bills/bill_status.py
@@ -1,0 +1,233 @@
+"""Parse a Maine Legislature bill status page into structured legislative history.
+
+Source: ``display_ps.asp?LD={ld}&snum={session}``. Recon (sprint track A1)
+established two things that decide this module's shape:
+
+* The page renders **identically for sessions 121 and 132**. There is no old/new
+  era split to branch on, so one parser covers 2003-2026. The sprint plan's
+  scale-back trigger — "status pages inconsistent across eras" — does not fire.
+* It is structured by stable element ids (``#flags``, ``#sec0``, ``#sec3``,
+  ``#sec6``), so parsing keys on those rather than on text position.
+
+``#paper_box`` and ``#ld_box`` look like the obvious source for the paper and LD
+numbers and are **not** — they are empty in the served HTML and filled by script.
+Both numbers come from ``<title>`` instead, which carries them server-side.
+
+robots.txt allows this path. It disallows ``/LawMakerWeb/`` and
+``default_ps.asp``, so neither is used here.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from bs4 import BeautifulSoup
+
+STATUS_URL = "https://legislature.maine.gov/legis/bills/display_ps.asp?LD={ld}&snum={session}"
+
+# "LD 1, SP 29, Text and Status, 132nd Legislature, First Special Session"
+_TITLE = re.compile(
+    r"LD\s+(?P<ld>\d+),\s*(?P<paper>[A-Z]{2}\s*\d+),.*?(?P<session>\d+)(?:st|nd|rd|th)\s+Legislature",
+    re.IGNORECASE,
+)
+
+# "Referred to Committee on Housing and Economic Development on Jan 28, 2025."
+_REFERRAL = re.compile(
+    r"Referred to Committee on\s+(?P<committee>.+?)\s+on\s+"
+    r"(?P<date>[A-Z][a-z]{2}\s+\d{1,2},\s+\d{4})",
+)
+
+# "Final Disposition Ought Not to Pass Pursuant To Joint Rule 310, Mar 20, 2003"
+_DISPOSITION = re.compile(
+    r"Final Disposition\s+(?P<disposition>.+?),\s*(?P<date>[A-Z][a-z]{2}\s+\d{1,2},\s+\d{4})",
+)
+
+# "Chaptered Law ACTPUB , Chapter 33"
+_CHAPTER = re.compile(r"Chaptered Law\s+(?P<law_type>[A-Z]+)\s*,\s*Chapter\s+(?P<chapter>\w+)")
+
+# "Governor's Action: Emergency Signed, Apr 22, 2025"
+_GOVERNOR = re.compile(
+    r"Governor'?s Action:\s*(?P<action>.+?),\s*(?P<date>[A-Z][a-z]{2}\s+\d{1,2},\s+\d{4})",
+)
+
+_DATE_FORMAT = "%b %d, %Y"
+
+
+def status_url(session: int, ld: int | str) -> str:
+    """URL of the status page for one bill."""
+    return STATUS_URL.format(ld=int(ld), session=int(session))
+
+
+def parse_date(value: str | None) -> str | None:
+    """ "Jan 15, 2025" -> "2025-01-15"; anything unparseable -> None.
+
+    Returning None rather than raising keeps one malformed cell from discarding
+    a whole bill's history — the raw text is preserved on the record either way.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value.strip(), _DATE_FORMAT).date().isoformat()
+    except ValueError:
+        return None
+
+
+@dataclass(frozen=True)
+class BillAction:
+    """One row of the committee docket."""
+
+    date: str | None  # ISO, None if the cell was empty or unparseable
+    action: str
+    result: str | None  # "ONTP", "OTP-AM", "REFERRED", ... often blank
+    raw_date: str | None = None
+
+
+@dataclass
+class BillStatus:
+    """Legislative history for one bill, as published on its status page."""
+
+    session: int
+    ld_number: str
+    paper: str | None = None
+    title: str | None = None
+    flags: list[str] = field(default_factory=list)  # EMERGENCY, GOVERNOR'S BILL
+    committee: str | None = None
+    referred_date: str | None = None
+    final_disposition: str | None = None
+    final_disposition_date: str | None = None
+    governor_action: str | None = None
+    governor_action_date: str | None = None
+    chaptered_law: str | None = None
+    actions: list[BillAction] = field(default_factory=list)
+    source_url: str = ""
+
+
+def _text(node) -> str:
+    return re.sub(r"\s+", " ", node.get_text(" ", strip=True)) if node else ""
+
+
+def _parse_bill_title(soup: BeautifulSoup) -> str | None:
+    """The bill's title, which is the page's ``<h2>``.
+
+    Not ``#legis_field_head`` despite the name — that id wraps the
+    "Choose Another Bill" legislature picker, so reading it yields the list of
+    every legislature from the 112th on. The ``<h1>`` is the legislature and
+    session; the ``<h3>`` is the picker's own heading.
+    """
+    h2 = soup.find("h2")
+    if h2 and _text(h2):
+        return _text(h2)
+
+    # Fall back to the longest heading that is neither the session line nor the
+    # picker, in case the heading level ever changes.
+    candidates = [
+        text
+        for h in soup.find_all(re.compile(r"^h[1-6]$"))
+        if (text := _text(h))
+        and "Legislature" not in text
+        and "Choose Another" not in text
+        and len(text) > 25
+    ]
+    return max(candidates, key=len) if candidates else None
+
+
+_DOCKET_HEADER = ["date", "action", "result"]
+
+
+def _find_docket(soup: BeautifulSoup) -> list:
+    """Rows of the committee docket, located by its header rather than position.
+
+    Two subtleties, both found against real pages:
+
+    * The header is **not** the first row — both tables on a status page open
+      with an empty or caption row, so row 0 must not be assumed to be it.
+    * Status pages carry a second table (affected statutes) whose header is
+      different, and an index would silently swap the two on a page where one
+      table is absent. So match on the header text and return what follows it.
+    """
+    for table in soup.find_all("table"):
+        rows = table.find_all("tr")
+        for i, row in enumerate(rows):
+            cells = [c.get_text(strip=True).lower() for c in row.find_all(["th", "td"])]
+            if cells[:3] == _DOCKET_HEADER:
+                return rows[i + 1 :]
+    return []
+
+
+def parse_actions(soup: BeautifulSoup) -> list[BillAction]:
+    """Committee docket rows, in page order."""
+    actions = []
+    for row in _find_docket(soup):
+        cells = [c.get_text(" ", strip=True) for c in row.find_all(["th", "td"])]
+        if len(cells) < 2 or not any(cells):
+            continue
+        raw_date, action = cells[0].strip(), cells[1].strip()
+        result = cells[2].strip() if len(cells) > 2 else ""
+        if not action:
+            continue
+        actions.append(
+            BillAction(
+                date=parse_date(raw_date),
+                action=action,
+                result=result or None,
+                raw_date=raw_date or None,
+            )
+        )
+    return actions
+
+
+def parse_status_page(html: str, session: int | None = None, ld: str | None = None) -> BillStatus:
+    """Parse one status page.
+
+    ``session`` and ``ld`` are read from the page title; pass them to override
+    when the caller already knows them (they are then trusted over the title).
+    """
+    soup = BeautifulSoup(html, "html.parser")
+
+    title_match = _TITLE.search(soup.title.get_text(strip=True) if soup.title else "")
+    parsed_ld = title_match.group("ld") if title_match else None
+    parsed_session = int(title_match.group("session")) if title_match else None
+    paper = re.sub(r"\s+", " ", title_match.group("paper")).strip() if title_match else None
+
+    resolved_session = session if session is not None else parsed_session
+    resolved_ld = ld if ld is not None else parsed_ld
+    if resolved_session is None or resolved_ld is None:
+        raise ValueError("Could not determine session/LD; page title did not match and no override")
+
+    status = BillStatus(
+        session=int(resolved_session),
+        ld_number=str(resolved_ld),
+        paper=paper,
+        source_url=status_url(int(resolved_session), resolved_ld),
+    )
+
+    flags = _text(soup.find(id="flags"))
+    status.flags = [f.strip() for f in re.findall(r"\(([^)]+)\)", flags)]
+
+    status.title = _parse_bill_title(soup)
+
+    committee_text = _text(soup.find(id="sec3"))
+    referral = _REFERRAL.search(committee_text)
+    if referral:
+        status.committee = referral.group("committee")
+        status.referred_date = parse_date(referral.group("date"))
+
+    disposition_text = _text(soup.find(id="sec0"))
+    disposition = _DISPOSITION.search(disposition_text)
+    if disposition:
+        status.final_disposition = disposition.group("disposition").strip()
+        status.final_disposition_date = parse_date(disposition.group("date"))
+
+    governor = _GOVERNOR.search(disposition_text)
+    if governor:
+        status.governor_action = governor.group("action").strip()
+        status.governor_action_date = parse_date(governor.group("date"))
+
+    chapter = _CHAPTER.search(disposition_text)
+    if chapter:
+        status.chaptered_law = f"{chapter.group('law_type')} Chapter {chapter.group('chapter')}"
+
+    status.actions = parse_actions(soup)
+    return status

--- a/src/maine_bills/legislature_roster.py
+++ b/src/maine_bills/legislature_roster.py
@@ -1,0 +1,200 @@
+"""Parse Maine Legislature member profile pages into roster entries.
+
+Source: ``legislature.maine.gov/District{N}``. Recon captured these while
+looking for the locality → legislator mapping issue #13 item 2 needs and
+OpenStates does not provide (it gives district numbers, not town names).
+
+Each page carries more than expected:
+
+    Sen. Trey Stewart (R-Aroostook)
+    District 2 : In Aroostook County: Amity; Bancroft Township; Blaine; ...
+    Legislative Service : Senate 130-132; House 128-129.
+
+So one page yields the member, their party, their county, every municipality
+they represent, and **which sessions they served** — the last of which lets a
+single current-session scrape answer questions about earlier sessions.
+
+Two limits worth stating plainly, because they bound what this can fix:
+
+* These pages exist only for the **current** legislature. A member who has left
+  has no page, so historical coverage reaches only as far back as the service
+  line of someone still serving. Sessions 121-124 are effectively out of reach —
+  robots.txt disallows ``/LawMakerWeb``, which was the only other route.
+* The district pages found so far are Senate seats. House members are published
+  through party caucus pages with a different shape, so House locality data
+  needs its own parser.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from bs4 import BeautifulSoup
+
+MEMBER_URL = "https://legislature.maine.gov/District{district}"
+
+# "Sen. Trey Stewart (R-Aroostook)"
+_HEADING = re.compile(
+    r"^(?P<title>Sen|Rep)\.\s+(?P<name>.+?)\s*\((?P<party>[A-Z])-(?P<county>[^)]+)\)",
+)
+
+# "District 2 : In Aroostook County: Amity; Bancroft Township; ..."
+_DISTRICT = re.compile(r"District\s+(?P<number>\d+)\s*:\s*(?P<body>.+?)(?=Mailing Address|$)", re.S)
+
+# "Legislative Service : Senate 130-132; House 128-129."
+_SERVICE = re.compile(r"Legislative Service\s*:\s*(?P<body>.+?)(?:\.|Committee Assignments)", re.S)
+_SERVICE_TERM = re.compile(r"(?P<chamber>Senate|House)\s+(?P<first>\d+)\s*(?:-\s*(?P<last>\d+))?")
+
+# "In Aroostook County: Amity; Bancroft Township; ..." — repeated per county.
+_COUNTY_NAME = r"[A-Z][A-Za-z .'-]+?"
+_COUNTY_BLOCK = re.compile(
+    rf"In\s+(?P<county>{_COUNTY_NAME})\s+County\s*:\s*(?P<towns>[^:]+?)"
+    rf"(?=In\s+{_COUNTY_NAME}\s+County\s*:|$)",
+    re.S,
+)
+
+# "All of Waldo County."
+_WHOLE_COUNTY = re.compile(r"All of\s+(?P<county>[A-Z][A-Za-z .'-]+?)\s+County")
+
+_CHAMBER_BY_TITLE = {"Sen": "Senate", "Rep": "House"}
+
+# The site uses single letters; OpenStates rosters spell them out, and these
+# entries are matched against those.
+_PARTY = {
+    "D": "Democratic",
+    "R": "Republican",
+    "I": "Independent",
+    "U": "Unenrolled",
+    "G": "Green",
+}
+
+
+@dataclass(frozen=True)
+class ServiceTerm:
+    """One stretch of service in one chamber, in session numbers."""
+
+    chamber: str
+    first_session: int
+    last_session: int
+
+    def covers(self, session: int) -> bool:
+        return self.first_session <= session <= self.last_session
+
+
+@dataclass
+class MemberProfile:
+    """A sitting legislator, as published on their profile page."""
+
+    name: str
+    family_name: str
+    chamber: str
+    party: str | None = None
+    county: str | None = None
+    district: str | None = None
+    localities: list[str] = field(default_factory=list)
+    service: list[ServiceTerm] = field(default_factory=list)
+    source_url: str = ""
+
+    def served_in(self, session: int) -> bool:
+        """Whether this member sat in the given session, per their service line."""
+        return any(term.covers(session) for term in self.service)
+
+    def chamber_in(self, session: int) -> str | None:
+        """Which chamber they sat in for that session — they may have switched."""
+        for term in self.service:
+            if term.covers(session):
+                return term.chamber
+        return None
+
+
+def member_url(district: int | str) -> str:
+    return MEMBER_URL.format(district=district)
+
+
+def family_name_of(full_name: str) -> str:
+    """Everything after the first token.
+
+    Bill text names sponsors by surname alone, and Maine has sitting members
+    with two-word surnames (Talbot Ross), so taking only the last token would
+    fail to match them. Taking everything after the given name matches those
+    correctly and mis-handles only a middle name, which these pages do not use.
+    """
+    parts = full_name.split()
+    return " ".join(parts[1:]) if len(parts) > 1 else full_name
+
+
+def parse_service(text: str) -> list[ServiceTerm]:
+    """ "Senate 130-132; House 128-129." -> two terms.
+
+    A single session appears without a range ("Senate 132"), which becomes a
+    term covering just that session.
+    """
+    match = _SERVICE.search(text)
+    if not match:
+        return []
+    terms = []
+    for term in _SERVICE_TERM.finditer(match.group("body")):
+        first = int(term.group("first"))
+        last = int(term.group("last")) if term.group("last") else first
+        terms.append(
+            ServiceTerm(chamber=term.group("chamber"), first_session=first, last_session=last)
+        )
+    return terms
+
+
+def parse_localities(body: str) -> list[str]:
+    """Municipalities in a district description, in page order.
+
+    Handles both published forms: an enumerated list per county
+    ("In Aroostook County: Amity; Bancroft Township; ...") and a whole county
+    ("All of Waldo County."), which yields the county as the single locality
+    since no town list is given.
+    """
+    localities: list[str] = []
+    for block in _COUNTY_BLOCK.finditer(body):
+        for town in block.group("towns").split(";"):
+            cleaned = re.sub(r"\s+", " ", town).strip(" .,")
+            if cleaned:
+                localities.append(cleaned)
+
+    if not localities:
+        for whole in _WHOLE_COUNTY.finditer(body):
+            localities.append(f"All of {whole.group('county').strip()} County")
+
+    return localities
+
+
+def parse_member_page(html: str, district: int | str | None = None) -> MemberProfile:
+    """Parse one member profile page."""
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup.find_all(["script", "style", "nav", "footer"]):
+        tag.decompose()
+
+    heading = soup.find("h1")
+    heading_text = re.sub(r"\s+", " ", heading.get_text(" ", strip=True)) if heading else ""
+    match = _HEADING.match(heading_text)
+    if not match:
+        raise ValueError(f"Not a member profile page; heading was {heading_text[:80]!r}")
+
+    name = match.group("name").strip()
+    text = re.sub(r"\s+", " ", soup.get_text(" ", strip=True))
+
+    district_match = _DISTRICT.search(text)
+    resolved_district = (
+        str(district)
+        if district is not None
+        else (district_match.group("number") if district_match else None)
+    )
+
+    return MemberProfile(
+        name=name,
+        family_name=family_name_of(name),
+        chamber=_CHAMBER_BY_TITLE[match.group("title")],
+        party=_PARTY.get(match.group("party"), match.group("party")),
+        county=match.group("county").strip(),
+        district=resolved_district,
+        localities=parse_localities(district_match.group("body")) if district_match else [],
+        service=parse_service(text),
+        source_url=member_url(resolved_district) if resolved_district else "",
+    )

--- a/src/maine_bills/legislature_roster.py
+++ b/src/maine_bills/legislature_roster.py
@@ -43,19 +43,38 @@ _HEADING = re.compile(
 _DISTRICT = re.compile(r"District\s+(?P<number>\d+)\s*:\s*(?P<body>.+?)(?=Mailing Address|$)", re.S)
 
 # "Legislative Service : Senate 130-132; House 128-129."
-_SERVICE = re.compile(r"Legislative Service\s*:\s*(?P<body>.+?)(?:\.|Committee Assignments)", re.S)
+#
+# The heading that follows is published both plural and singular, and not every
+# page ends the service line with a period -- District 10 runs straight on:
+#   "Legislative Service : Senate 132; House 128-131 Committee Assignment : ..."
+# Requiring the plural silently produced an empty service list for a sitting
+# senator, so accept either and stop at whichever terminator comes first.
+_SERVICE = re.compile(
+    r"Legislative Service\s*:\s*(?P<body>.+?)(?:\.|Committee\s+Assignments?)",
+    re.S,
+)
 _SERVICE_TERM = re.compile(r"(?P<chamber>Senate|House)\s+(?P<first>\d+)\s*(?:-\s*(?P<last>\d+))?")
 
 # "In Aroostook County: Amity; Bancroft Township; ..." — repeated per county.
 _COUNTY_NAME = r"[A-Z][A-Za-z .'-]+?"
+# A town list runs until the next county block or a whole-county clause. Without
+# the "All of" arm, a page mixing the two forms glues the second onto the last
+# town: "...; and Owls Head. All of Waldo County".
 _COUNTY_BLOCK = re.compile(
     rf"In\s+(?P<county>{_COUNTY_NAME})\s+County\s*:\s*(?P<towns>[^:]+?)"
-    rf"(?=In\s+{_COUNTY_NAME}\s+County\s*:|$)",
+    rf"(?=In\s+{_COUNTY_NAME}\s+County\s*:|All of\s+{_COUNTY_NAME}\s+County|$)",
     re.S,
 )
 
 # "All of Waldo County."
 _WHOLE_COUNTY = re.compile(r"All of\s+(?P<county>[A-Z][A-Za-z .'-]+?)\s+County")
+
+# The site writes town lists with a serial conjunction: "A; B; and C." and, when
+# a county has only two, with no semicolon at all: "Bangor and Hermon." Splitting
+# on ";" alone yields "and Weston" (16 of 235 localities across the district
+# pages) and loses Bangor entirely. No Maine municipality name contains " and ",
+# so it is safe to treat as a separator wherever it appears.
+_LIST_SEPARATOR = re.compile(r";|\band\b")
 
 _CHAMBER_BY_TITLE = {"Sen": "Senate", "Rep": "House"}
 
@@ -95,9 +114,23 @@ class MemberProfile:
     localities: list[str] = field(default_factory=list)
     service: list[ServiceTerm] = field(default_factory=list)
     source_url: str = ""
+    # Raw text of the service line when one was published. Lets a caller tell
+    # "this member has no service line" from "the line was there and we failed
+    # to parse it" -- served_in() collapses both to False, which is how a
+    # sitting senator silently read as never having served.
+    service_raw: str | None = None
+
+    @property
+    def service_unparsed(self) -> bool:
+        """A service line was published but yielded no terms."""
+        return self.service_raw is not None and not self.service
 
     def served_in(self, session: int) -> bool:
-        """Whether this member sat in the given session, per their service line."""
+        """Whether this member sat in the given session, per their service line.
+
+        False also when the line failed to parse; check ``service_unparsed``
+        before treating a False as evidence of absence.
+        """
         return any(term.covers(session) for term in self.service)
 
     def chamber_in(self, session: int) -> str | None:
@@ -119,9 +152,20 @@ def family_name_of(full_name: str) -> str:
     with two-word surnames (Talbot Ross), so taking only the last token would
     fail to match them. Taking everything after the given name matches those
     correctly and mis-handles only a middle name, which these pages do not use.
+
+    Known gap: a published middle initial or a suffix comes through attached --
+    "H. Scott Landry" -> "Scott Landry", "Anne Perry Jr." -> "Perry Jr." Maine
+    does seat members published with a middle initial, so this needs a guard
+    before the values feed sponsor_matching.
     """
     parts = full_name.split()
     return " ".join(parts[1:]) if len(parts) > 1 else full_name
+
+
+def service_text(text: str) -> str | None:
+    """The raw service line, or None if the page publishes none."""
+    match = _SERVICE.search(text)
+    return match.group("body").strip() if match else None
 
 
 def parse_service(text: str) -> list[ServiceTerm]:
@@ -146,21 +190,31 @@ def parse_service(text: str) -> list[ServiceTerm]:
 def parse_localities(body: str) -> list[str]:
     """Municipalities in a district description, in page order.
 
-    Handles both published forms: an enumerated list per county
-    ("In Aroostook County: Amity; Bancroft Township; ...") and a whole county
-    ("All of Waldo County."), which yields the county as the single locality
-    since no town list is given.
+    Both published forms are handled, and a page may use both. An enumerated
+    list per county:
+
+        In Aroostook County: Amity; Bancroft Township; ... and Weston.
+
+    and a whole county, which yields the county itself since no towns are given:
+
+        All of Waldo County.
+
+    Entries are split on the serial conjunction as well as the semicolon.
+    Splitting on ";" alone leaves the last town of every block prefixed "and "
+    -- a plausible-looking string that never joins to anything -- and drops the
+    second town outright where a county lists two without a semicolon.
     """
     localities: list[str] = []
     for block in _COUNTY_BLOCK.finditer(body):
-        for town in block.group("towns").split(";"):
+        for town in _LIST_SEPARATOR.split(block.group("towns")):
             cleaned = re.sub(r"\s+", " ", town).strip(" .,")
             if cleaned:
                 localities.append(cleaned)
 
-    if not localities:
-        for whole in _WHOLE_COUNTY.finditer(body):
-            localities.append(f"All of {whole.group('county').strip()} County")
+    # Unconditional, not a fallback: a district can enumerate towns in one
+    # county and take another whole.
+    for whole in _WHOLE_COUNTY.finditer(body):
+        localities.append(f"All of {whole.group('county').strip()} County")
 
     return localities
 
@@ -196,5 +250,6 @@ def parse_member_page(html: str, district: int | str | None = None) -> MemberPro
         district=resolved_district,
         localities=parse_localities(district_match.group("body")) if district_match else [],
         service=parse_service(text),
+        service_raw=service_text(text),
         source_url=member_url(resolved_district) if resolved_district else "",
     )

--- a/tests/unit/test_bill_status.py
+++ b/tests/unit/test_bill_status.py
@@ -11,11 +11,13 @@ from bs4 import BeautifulSoup
 
 from maine_bills.bill_status import (
     BillAction,
+    normalize_ld,
     parse_actions,
     parse_date,
     parse_status_page,
     status_url,
 )
+from maine_bills.schema import parse_filename
 
 
 def page(
@@ -159,13 +161,36 @@ def test_title_falls_back_when_there_is_no_h2():
 
 def test_identifiers_come_from_the_title_since_the_boxes_are_script_filled():
     status = parse_status_page(page(ld="1", paper="SP 29", session="132nd"))
-    assert (status.session, status.ld_number, status.paper) == (132, "1", "SP 29")
+    assert (status.session, status.ld_number, status.paper) == (132, "0001", "SP 29")
 
 
 def test_overrides_win_over_the_page_title():
-    status = parse_status_page(page(), session=131, ld="0042")
+    status = parse_status_page(page(), session=131, ld="42")
     assert status.session == 131
     assert status.ld_number == "0042"
+
+
+# --- ld_number must key against the published dataset ---
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [(1, "0001"), ("1", "0001"), ("0001", "0001"), (42, "0042"), ("2196", "2196"), (" 7 ", "0007")],
+)
+def test_normalize_ld_pads_to_the_schema_width(raw, expected):
+    assert normalize_ld(raw) == expected
+
+
+def test_ld_number_joins_against_parse_filename():
+    """The page title says "LD 1"; BillRecord.ld_number is "0001". Storing the
+    page's form would make every join against the published dataset miss."""
+    status = parse_status_page(page(ld="1", session="132nd"))
+    assert status.ld_number == parse_filename("132-LD-0001")["ld_number"]
+
+
+def test_status_url_still_strips_the_padding():
+    """Deliberate asymmetry: the site wants LD=1, not LD=0001."""
+    assert status_url(132, "0001").endswith("LD=1&snum=132")
 
 
 def test_unrecognisable_page_raises_rather_than_guessing():

--- a/tests/unit/test_bill_status.py
+++ b/tests/unit/test_bill_status.py
@@ -1,0 +1,250 @@
+"""Tests for bill status page parsing (sprint track A1).
+
+Fixtures mirror the real structure of ``display_ps.asp`` as captured on the
+``fixtures/recon`` branch — the empty leading row in both tables, the ``<h1>``
+session line, the ``#legis_field_head`` picker, and the ``#sec*`` containers —
+because two of the parser's bugs came from assuming otherwise.
+"""
+
+import pytest
+from bs4 import BeautifulSoup
+
+from maine_bills.bill_status import (
+    BillAction,
+    parse_actions,
+    parse_date,
+    parse_status_page,
+    status_url,
+)
+
+
+def page(
+    *,
+    session="132nd",
+    session_name="First Special Session",
+    ld="1",
+    paper="SP 29",
+    title="An Act to Increase Storm Preparedness",
+    flags="(EMERGENCY) (GOVERNOR'S BILL)",
+    sec0="",
+    sec3="",
+    docket_rows=(),
+    include_statutes=True,
+):
+    """Build a page with the real page's structure."""
+    rows = "".join(f"<tr><td>{d}</td><td>{a}</td><td>{r}</td></tr>" for d, a, r in docket_rows)
+    docket = (
+        # The real table opens with an EMPTY row; the header is row 1.
+        "<table><tr><td></td></tr>"
+        "<tr><td>Date</td><td>Action</td><td>Result</td></tr>"
+        f"{rows}</table>"
+        if docket_rows
+        else ""
+    )
+    statutes = (
+        "<table><tr><td>Affected Statute Titles and Sections</td></tr>"
+        "<tr><td>Title</td><td>Section</td><td>Subsection</td><td>Paragraph</td>"
+        "<td>Effect</td><td>Law Type</td><td>Chapter</td></tr>"
+        "<tr><td>5</td><td>3109</td><td>2</td><td></td><td>AMD</td>"
+        "<td>Public Law</td><td>33</td></tr></table>"
+        if include_statutes
+        else ""
+    )
+    return f"""
+    <html><head><title>LD {ld}, {paper}, Text and Status, {session} Legislature,
+    {session_name}</title></head><body>
+      <h1>{session} Maine Legislature, {session_name}</h1>
+      <div id="legis_field_head">Legislature 132nd 131st 130th 129th 128th 127th
+        126th 125th 124th 123rd 122nd 121st 120th</div>
+      <h3>Choose Another Bill</h3>
+      <h2>{title}</h2>
+      <div id="paper_box"></div><div id="ld_box"></div>
+      <div id="flags">{flags}</div>
+      <div id="sec0">Documents and Disposition LD {ld}, {paper} {sec0}</div>
+      <div id="sec3">Status In Committee {sec3}{docket}</div>
+      <div id="sec6">{statutes}</div>
+    </body></html>
+    """
+
+
+# --- status_url ---
+
+
+def test_status_url_uses_the_robots_allowed_path():
+    url = status_url(132, 1)
+    assert url == "https://legislature.maine.gov/legis/bills/display_ps.asp?LD=1&snum=132"
+    # robots.txt disallows default_ps.asp, search_ps.asp and /LawMakerWeb
+    assert "default_ps" not in url and "LawMakerWeb" not in url
+
+
+def test_status_url_accepts_a_string_ld():
+    assert status_url(121, "0001").endswith("LD=1&snum=121")
+
+
+# --- parse_date ---
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Jan 15, 2025", "2025-01-15"),
+        ("Mar 6, 2025", "2025-03-06"),
+        ("Dec 31, 2003", "2003-12-31"),
+        ("", None),
+        (None, None),
+        ("not a date", None),
+        ("15 January 2025", None),
+    ],
+)
+def test_parse_date(raw, expected):
+    assert parse_date(raw) == expected
+
+
+# --- the docket header is not row 0 ---
+
+
+def test_docket_header_is_found_below_an_empty_leading_row():
+    """Regression: assuming row 0 was the header returned zero actions."""
+    html = page(docket_rows=[("Jan 15, 2025", "Voted", "REFERRED")])
+    actions = parse_actions(BeautifulSoup(html, "html.parser"))
+    assert actions == [
+        BillAction(date="2025-01-15", action="Voted", result="REFERRED", raw_date="Jan 15, 2025")
+    ]
+
+
+def test_affected_statutes_table_is_not_mistaken_for_the_docket():
+    """Both tables exist; a positional index would pick the wrong one."""
+    html = page(docket_rows=[], include_statutes=True)
+    assert parse_actions(BeautifulSoup(html, "html.parser")) == []
+
+
+def test_blank_result_becomes_none_not_empty_string():
+    html = page(docket_rows=[("Jan 15, 2025", "Work Session Held", "")])
+    assert parse_actions(BeautifulSoup(html, "html.parser"))[0].result is None
+
+
+def test_unparseable_date_keeps_the_row_and_the_raw_text():
+    """One bad cell must not discard a bill's history."""
+    html = page(docket_rows=[("Indeterminate", "Voted", "ONTP")])
+    action = parse_actions(BeautifulSoup(html, "html.parser"))[0]
+    assert action.date is None
+    assert action.raw_date == "Indeterminate"
+    assert action.action == "Voted"
+
+
+def test_rows_without_an_action_are_skipped():
+    html = page(docket_rows=[("Jan 15, 2025", "", ""), ("Jan 16, 2025", "Voted", "OTP")])
+    actions = parse_actions(BeautifulSoup(html, "html.parser"))
+    assert [a.action for a in actions] == ["Voted"]
+
+
+# --- the title is the h2 ---
+
+
+def test_title_is_the_bill_not_the_legislature_picker():
+    """Regression: #legis_field_head is the picker, and yields a list of
+    legislatures rather than the bill's title."""
+    status = parse_status_page(page(title="An Act to Do a Specific Thing"))
+    assert status.title == "An Act to Do a Specific Thing"
+    assert "131st" not in (status.title or "")
+
+
+def test_title_falls_back_when_there_is_no_h2():
+    html = page().replace("<h2>", "<h4>").replace("</h2>", "</h4>")
+    assert parse_status_page(html).title == "An Act to Increase Storm Preparedness"
+
+
+# --- identifiers ---
+
+
+def test_identifiers_come_from_the_title_since_the_boxes_are_script_filled():
+    status = parse_status_page(page(ld="1", paper="SP 29", session="132nd"))
+    assert (status.session, status.ld_number, status.paper) == (132, "1", "SP 29")
+
+
+def test_overrides_win_over_the_page_title():
+    status = parse_status_page(page(), session=131, ld="0042")
+    assert status.session == 131
+    assert status.ld_number == "0042"
+
+
+def test_unrecognisable_page_raises_rather_than_guessing():
+    with pytest.raises(ValueError, match="Could not determine session/LD"):
+        parse_status_page("<html><head><title>Error</title></head><body/></html>")
+
+
+def test_flags_are_split():
+    assert parse_status_page(page()).flags == ["EMERGENCY", "GOVERNOR'S BILL"]
+
+
+def test_no_flags_is_an_empty_list():
+    assert parse_status_page(page(flags="")).flags == []
+
+
+# --- prose fields ---
+
+
+def test_committee_referral():
+    status = parse_status_page(
+        page(sec3="Referred to Committee on Housing and Economic Development on Jan 28, 2025.")
+    )
+    assert status.committee == "Housing and Economic Development"
+    assert status.referred_date == "2025-01-28"
+
+
+def test_final_disposition_and_governor_action():
+    status = parse_status_page(
+        page(
+            sec0="Final Disposition Emergency Enacted, Apr 22, 2025 "
+            "Governor's Action: Emergency Signed, Apr 22, 2025 "
+            "Chaptered Law ACTPUB , Chapter 33"
+        )
+    )
+    assert status.final_disposition == "Emergency Enacted"
+    assert status.final_disposition_date == "2025-04-22"
+    assert status.governor_action == "Emergency Signed"
+    assert status.chaptered_law == "ACTPUB Chapter 33"
+
+
+def test_a_bill_that_died_has_a_disposition_and_no_chapter():
+    status = parse_status_page(
+        page(sec0="Final Disposition Ought Not to Pass Pursuant To Joint Rule 310, Mar 20, 2003")
+    )
+    assert status.final_disposition == "Ought Not to Pass Pursuant To Joint Rule 310"
+    assert status.chaptered_law is None
+    assert status.governor_action is None
+
+
+# --- the two eras parse identically ---
+
+
+def test_session_121_and_132_take_the_same_path():
+    """Recon established the page renders identically across eras; if that ever
+    stops being true, this is where it shows up."""
+    old = parse_status_page(
+        page(
+            session="121st",
+            session_name="First Regular Session",
+            paper="HP 8",
+            title="An Act to Increase the Property Tax Exemption for Veterans",
+            flags="",
+            sec3="Referred to Committee on Taxation on Jan 9, 2003.",
+            sec0="Final Disposition Ought Not to Pass Pursuant To Joint Rule 310, Mar 20, 2003",
+            docket_rows=[
+                ("Mar 13, 2003", "Work Session Held", ""),
+                ("Mar 13, 2003", "Voted", "ONTP"),
+                ("Mar 17, 2003", "Reported Out", "ONTP"),
+            ],
+        )
+    )
+    new = parse_status_page(
+        page(
+            sec3="Referred to Committee on Housing and Economic Development on Jan 28, 2025.",
+            docket_rows=[("Jan 15, 2025", "Voted", "REFERRED")],
+        )
+    )
+
+    assert old.session == 121 and new.session == 132
+    assert old.committee == "Taxation" and new.committee == "Housing and Economic Development"
+    assert [a.result for a in old.actions] == [None, "ONTP", "ONTP"]
+    assert len(new.actions) == 1

--- a/tests/unit/test_legislature_roster.py
+++ b/tests/unit/test_legislature_roster.py
@@ -17,29 +17,60 @@ from maine_bills.legislature_roster import (
     parse_service,
 )
 
-STEWART = """
-<html><head><title>Sen. Trey Stewart (R-Aroostook) | Maine State Legislature</title></head>
+
+def _page(heading, district_line, service_line):
+    """Wrap real page text in the real page's structure."""
+    return f"""
+<html><head><title>{heading} | Maine State Legislature</title></head>
 <body>
-  <h1>Sen. Trey Stewart (R-Aroostook)</h1>
-  <p>District 2 : In Aroostook County: Amity; Bancroft Township; Blaine;
-  Bridgewater; Central Aroostook UT. In Penobscot County: Chester;
-  Drew Plantation; East Millinocket.
+  <h1>{heading}</h1>
+  <p>{district_line}
   Mailing Address: 3 State House Station, Augusta, Maine 04333</p>
-  <p>Legislative Service : Senate 130-132; House 128-129.
-  Committee Assignments : Senate Republican Minority Leader</p>
+  <p>{service_line}</p>
 </body></html>
 """
 
-CURRY = """
-<html><head><title>Sen. Chip Curry (D-Waldo) | Maine State Legislature</title></head>
-<body>
-  <h1>Sen. Chip Curry (D-Waldo)</h1>
-  <p>District 11 : All of Waldo County.
-  Mailing Address: 3 State House Station, Augusta, Maine 04333</p>
-  <p>Legislative Service : Senate 130-132.
-  Committee Assignments : Housing and Economic Development (Chair)</p>
-</body></html>
-"""
+
+# Text below is copied from the real pages on `fixtures/recon`, quirks intact.
+# An earlier draft of these fixtures was hand-written and tidied — it dropped
+# the serial "and", used a semicolon where the site uses none, and normalized
+# the service heading to the plural. All 22 tests passed against a parser that
+# mangled every real page. Do not sanitize these.
+
+# District 2 — serial conjunction closes each county block: "...; and Weston."
+STEWART = _page(
+    "Sen. Trey Stewart (R-Aroostook)",
+    "District 2 : In Aroostook County: Amity; Bancroft Township; Blaine; "
+    "Bridgewater; Central Aroostook UT; and Weston. "
+    "In Penobscot County: Chester; Drew Plantation; and Woodville.",
+    "Legislative Service : Senate 130-132; House 128-129. "
+    "Committee Assignments : Senate Republican Minority Leader",
+)
+
+# District 9 — two towns, no semicolon at all. Splitting on ";" loses Bangor.
+BALDACCI = _page(
+    "Sen. Joe Baldacci (D-Penobscot)",
+    "District 9 : In Penobscot County: Bangor and Hermon.",
+    "Legislative Service : Senate 130-132. "
+    "Committee Assignments : Inland Fisheries and Wildlife (Chair)",
+)
+
+# District 10 — service heading is SINGULAR and the line has no closing period.
+HAGGAN = _page(
+    "Sen. David Haggan (R-Penobscot)",
+    "District 10 : In Hancock County: Bucksport; Dedham; and Otis. "
+    "In Penobscot County: Bradley; Brewer; Carmel; and Orrington.",
+    "Legislative Service : Senate 132; House 128-131 "
+    "Committee Assignment : Health Coverage, Insurance, and Financial Services",
+)
+
+# District 11 — whole county, no town list published.
+CURRY = _page(
+    "Sen. Chip Curry (D-Waldo)",
+    "District 11 : All of Waldo County.",
+    "Legislative Service : Senate 130-132. "
+    "Committee Assignments : Housing and Economic Development (Chair)",
+)
 
 
 # --- heading ---
@@ -99,6 +130,47 @@ def test_enumerated_towns_across_multiple_counties():
     assert not any(loc.startswith("In ") for loc in localities)
 
 
+# --- the serial conjunction, which every real county block ends with ---
+
+
+def test_last_town_of_a_block_is_not_prefixed_with_and():
+    """Regression: splitting on ";" alone yielded "and Weston".
+
+    16 of 235 localities across the real District pages came out this way — a
+    plausible-looking string that will never join to the town it names.
+    """
+    localities = parse_member_page(STEWART).localities
+    assert "Weston" in localities
+    assert "Woodville" in localities  # last town of the second block too
+    assert not any(loc.lower().startswith("and ") for loc in localities)
+
+
+def test_two_towns_with_no_semicolon_are_both_captured():
+    """Regression: District 9 publishes "Bangor and Hermon." with no semicolon,
+    and splitting on ";" alone returned one string — losing Bangor entirely."""
+    localities = parse_member_page(BALDACCI).localities
+    assert localities == ["Bangor", "Hermon"]
+
+
+def test_and_inside_a_block_is_a_separator_everywhere():
+    localities = parse_member_page(HAGGAN).localities
+    assert "Otis" in localities
+    assert "Orrington" in localities
+    assert not any(" and " in loc for loc in localities)
+
+
+def test_mixed_enumerated_and_whole_county_forms():
+    """The whole-county clause used to be a fallback, so on a mixed page it
+    glued onto the last town: 'and Owls Head. All of Waldo County'."""
+    body = "In Knox County: Rockland; Thomaston; and Owls Head. All of Waldo County."
+    assert parse_localities(body) == [
+        "Rockland",
+        "Thomaston",
+        "Owls Head",
+        "All of Waldo County",
+    ]
+
+
 def test_whole_county_districts_record_the_county():
     """No town list is published for these, so the county is the locality."""
     assert parse_member_page(CURRY).localities == ["All of Waldo County"]
@@ -114,6 +186,32 @@ def test_parse_localities_on_an_empty_body():
 
 
 # --- legislative service ---
+
+
+def test_singular_committee_heading_without_a_period():
+    """Regression: District 10 publishes "Committee Assignment" singular and no
+    closing period, so requiring the plural returned no service at all — a
+    sitting senator read as never having served."""
+    member = parse_member_page(HAGGAN)
+    assert member.service == [
+        ServiceTerm(chamber="Senate", first_session=132, last_session=132),
+        ServiceTerm(chamber="House", first_session=128, last_session=131),
+    ]
+    assert member.served_in(132) is True
+    assert member.service_unparsed is False
+
+
+def test_unparsed_service_is_distinguishable_from_absent_service():
+    """served_in() returns False for both; the caller must be able to tell."""
+    absent = _page("Sen. A B (D-Knox)", "District 1 : All of Knox County.", "No service line.")
+    unparsed = _page(
+        "Sen. C D (D-Knox)",
+        "District 1 : All of Knox County.",
+        "Legislative Service : ??? Committee Assignments : x",
+    )
+    assert parse_member_page(absent).service_unparsed is False
+    assert parse_member_page(unparsed).service_unparsed is True
+    assert parse_member_page(unparsed).served_in(132) is False
 
 
 def test_service_across_two_chambers():

--- a/tests/unit/test_legislature_roster.py
+++ b/tests/unit/test_legislature_roster.py
@@ -1,0 +1,183 @@
+"""Tests for member profile parsing (issue #13 items 1 and 2).
+
+Fixtures reproduce the real shape of ``legislature.maine.gov/District{N}`` as
+captured on ``fixtures/recon``, including both published locality forms — an
+enumerated town list per county, and a whole county.
+"""
+
+import pytest
+
+from maine_bills.legislature_roster import (
+    MemberProfile,
+    ServiceTerm,
+    family_name_of,
+    member_url,
+    parse_localities,
+    parse_member_page,
+    parse_service,
+)
+
+STEWART = """
+<html><head><title>Sen. Trey Stewart (R-Aroostook) | Maine State Legislature</title></head>
+<body>
+  <h1>Sen. Trey Stewart (R-Aroostook)</h1>
+  <p>District 2 : In Aroostook County: Amity; Bancroft Township; Blaine;
+  Bridgewater; Central Aroostook UT. In Penobscot County: Chester;
+  Drew Plantation; East Millinocket.
+  Mailing Address: 3 State House Station, Augusta, Maine 04333</p>
+  <p>Legislative Service : Senate 130-132; House 128-129.
+  Committee Assignments : Senate Republican Minority Leader</p>
+</body></html>
+"""
+
+CURRY = """
+<html><head><title>Sen. Chip Curry (D-Waldo) | Maine State Legislature</title></head>
+<body>
+  <h1>Sen. Chip Curry (D-Waldo)</h1>
+  <p>District 11 : All of Waldo County.
+  Mailing Address: 3 State House Station, Augusta, Maine 04333</p>
+  <p>Legislative Service : Senate 130-132.
+  Committee Assignments : Housing and Economic Development (Chair)</p>
+</body></html>
+"""
+
+
+# --- heading ---
+
+
+def test_parses_name_party_county_and_chamber():
+    member = parse_member_page(STEWART)
+    assert member.name == "Trey Stewart"
+    assert member.chamber == "Senate"
+    assert member.party == "Republican"  # spelled out to match OpenStates rosters
+    assert member.county == "Aroostook"
+    assert member.district == "2"
+
+
+def test_democratic_party_letter_is_expanded():
+    assert parse_member_page(CURRY).party == "Democratic"
+
+
+def test_a_non_profile_page_raises():
+    with pytest.raises(ValueError, match="Not a member profile page"):
+        parse_member_page("<html><body><h1>Maine State Legislature</h1></body></html>")
+
+
+def test_representative_pages_map_to_the_house():
+    html = STEWART.replace("Sen. Trey Stewart", "Rep. Trey Stewart")
+    assert parse_member_page(html).chamber == "House"
+
+
+# --- family name ---
+
+
+@pytest.mark.parametrize(
+    "full,expected",
+    [
+        ("Trey Stewart", "Stewart"),
+        ("Chip Curry", "Curry"),
+        # Sitting members with two-word surnames: taking only the last token
+        # would fail to match "TALBOT ROSS" as it appears in bill text.
+        ("Rachel Talbot Ross", "Talbot Ross"),
+        ("Marianne Beebe-Center", "Beebe-Center"),
+        ("Mononym", "Mononym"),
+    ],
+)
+def test_family_name_of(full, expected):
+    assert family_name_of(full) == expected
+
+
+# --- localities ---
+
+
+def test_enumerated_towns_across_multiple_counties():
+    localities = parse_member_page(STEWART).localities
+    assert "Amity" in localities
+    assert "Bancroft Township" in localities
+    assert "Chester" in localities  # second county block
+    assert "Drew Plantation" in localities
+    assert not any(loc.startswith("In ") for loc in localities)
+
+
+def test_whole_county_districts_record_the_county():
+    """No town list is published for these, so the county is the locality."""
+    assert parse_member_page(CURRY).localities == ["All of Waldo County"]
+
+
+def test_localities_stop_before_the_mailing_address():
+    assert not any("Augusta" in loc for loc in parse_member_page(STEWART).localities)
+    assert not any("State House" in loc for loc in parse_member_page(CURRY).localities)
+
+
+def test_parse_localities_on_an_empty_body():
+    assert parse_localities("") == []
+
+
+# --- legislative service ---
+
+
+def test_service_across_two_chambers():
+    service = parse_member_page(STEWART).service
+    assert service == [
+        ServiceTerm(chamber="Senate", first_session=130, last_session=132),
+        ServiceTerm(chamber="House", first_session=128, last_session=129),
+    ]
+
+
+def test_a_single_session_has_no_range():
+    assert parse_service("Legislative Service : Senate 132. Committee Assignments : x") == [
+        ServiceTerm(chamber="Senate", first_session=132, last_session=132)
+    ]
+
+
+def test_absent_service_line_is_empty_not_an_error():
+    assert parse_service("no such line here") == []
+
+
+# --- session coverage, which is what makes these pages worth scraping ---
+
+
+def test_served_in_spans_both_chambers():
+    """One current page answers for earlier sessions — that is the whole point.
+
+    A member who moved chambers covers 128-132 from a single fetch, which
+    reaches into the 125-130 ambiguity band issue #13 item 2 is about.
+    """
+    member = parse_member_page(STEWART)
+    assert [s for s in range(124, 134) if member.served_in(s)] == [128, 129, 130, 131, 132]
+
+
+def test_chamber_in_follows_the_move_between_chambers():
+    member = parse_member_page(STEWART)
+    assert member.chamber_in(128) == "House"
+    assert member.chamber_in(131) == "Senate"
+    assert member.chamber_in(121) is None
+
+
+def test_a_first_term_member_does_not_claim_earlier_sessions():
+    member = parse_member_page(CURRY)
+    assert member.served_in(130) is True
+    assert member.served_in(129) is False
+    assert member.served_in(125) is False
+
+
+# --- url ---
+
+
+def test_member_url():
+    assert member_url(11) == "https://legislature.maine.gov/District11"
+    assert parse_member_page(CURRY).source_url == "https://legislature.maine.gov/District11"
+
+
+def test_district_override_wins():
+    assert parse_member_page(STEWART, district=99).district == "99"
+
+
+# --- the dataclass contract used downstream ---
+
+
+def test_profile_defaults_are_empty_not_none():
+    member = MemberProfile(name="A B", family_name="B", chamber="Senate")
+    assert member.localities == []
+    assert member.service == []
+    assert member.served_in(132) is False

--- a/tests/unit/test_recon_legislature.py
+++ b/tests/unit/test_recon_legislature.py
@@ -204,6 +204,57 @@ def test_crawl_respects_the_page_cap(recon, tmp_path):
     assert len(records) == 5
 
 
+def test_focus_confines_the_crawl_to_one_category(recon, tmp_path):
+    """The first run spent 42 of 60 pages on the bill directory and never
+    reached a member list; --focus roster is what prevents that."""
+    root = "https://legislature.maine.gov/senate/senators/9536"
+    roster = "https://legislature.maine.gov/senate/district-listing/9526"
+    bills = "https://legislature.maine.gov/bills/billdirectory_ps.asp?snum=132&ldFrom=0"
+    html = (
+        f'<html><title>Senators</title><body><a href="{roster}">Senators by District</a>'
+        f'<a href="{bills}">Bill Directory</a></body></html>'
+    )
+    pages = {
+        root: FakeResponse(root, text=html),
+        roster: FakeResponse(roster, text="<html><title>Districts</title></html>"),
+        bills: FakeResponse(bills, text="<html><title>Bills</title></html>"),
+    }
+
+    unfocused_dir = tmp_path / "unfocused"
+    focused_dir = tmp_path / "focused"
+    unfocused_dir.mkdir()
+    focused_dir.mkdir()
+
+    http = FakeSession(pages)
+    unfocused = recon.crawl([root], http, unfocused_dir, max_pages=10, delay=0, robots=_AllowAll())
+    assert bills in [r["url"] for r in unfocused]
+
+    http = FakeSession(pages)
+    focused = recon.crawl(
+        [root],
+        http,
+        focused_dir,
+        max_pages=10,
+        delay=0,
+        robots=_AllowAll(),
+        categories={"roster"},
+    )
+    urls = [r["url"] for r in focused]
+    assert roster in urls
+    assert bills not in urls
+
+
+def test_party_caucus_links_count_as_roster(recon):
+    """Caucus pages carry the member lists but their text says "House Democrats"."""
+    for href, text in [
+        ("https://legislature.maine.gov/housedems/", "House Democrats"),
+        ("/house-independents/house-independents/9453", "House Independents"),
+        ("/senate/find-your-state-senator/9392", "Senators Listed by Municipality"),
+        ("/senate/district-listing/9526", "Senators Listed by Senate District"),
+    ]:
+        assert "roster" in recon.classify(href, text), href
+
+
 def test_crawl_records_failures_without_raising(recon, tmp_path):
     missing = "https://legislature.maine.gov/legis/nope/"
     http = FakeSession({})

--- a/tests/unit/test_recon_legislature.py
+++ b/tests/unit/test_recon_legislature.py
@@ -346,3 +346,47 @@ def test_seeds_are_formatted_with_the_session(recon, tmp_path, monkeypatch):
     index = json.loads((tmp_path / "session-121" / "recon-index.json").read_text())
     assert any("snum=121" in seed for seed in index["seeds"])
     assert not any("{session}" in seed for seed in index["seeds"])
+
+
+# --- robots.txt capture ---
+
+
+def test_directive_reads_crawl_delay(recon):
+    body = "User-agent: *\nCrawl-delay: 10\nDisallow: /LawMakerWeb/\n"
+    assert recon._directive(body, "crawl-delay") == "10"
+    assert recon._directive(body, "request-rate") is None
+
+
+def test_directive_ignores_comments_and_case(recon):
+    body = "# Crawl-delay: 99\nUser-agent: *\nCRAWL-DELAY: 5  # be nice\n"
+    assert recon._directive(body, "crawl-delay") == "5"
+
+
+def test_robots_policy_keeps_the_raw_text(recon):
+    robots_url = "https://legislature.maine.gov/robots.txt"
+    body = "User-agent: *\nCrawl-delay: 10\nDisallow: /LawMakerWeb/\n"
+    http = FakeSession({robots_url: FakeResponse(robots_url, text=body)})
+    policy = recon.RobotsPolicy(http)
+    policy.allows("https://legislature.maine.gov/a")
+    assert policy.raw["legislature.maine.gov"] == body
+
+
+def test_main_records_and_saves_robots(recon, tmp_path, monkeypatch):
+    robots_url = "https://legislature.maine.gov/robots.txt"
+    body = "User-agent: *\nCrawl-delay: 10\n"
+    monkeypatch.setattr(
+        recon.requests,
+        "Session",
+        lambda: FakeSession({robots_url: FakeResponse(robots_url, text=body)}),
+    )
+    monkeypatch.setattr(
+        recon.sys,
+        "argv",
+        ["recon_legislature.py", "--session", "132", "--out", str(tmp_path), "--delay", "0"],
+    )
+    recon.main()
+
+    out = tmp_path / "session-132"
+    index = json.loads((out / "recon-index.json").read_text())
+    assert index["robots"]["legislature.maine.gov"]["crawl_delay"] == "10"
+    assert (out / "robots-legislature.maine.gov.txt").read_text() == body


### PR DESCRIPTION
Two parsers and the recon that made both writable. Unblocks sprint node **N3** and issue #13 items 1–2.

> Kept as one PR. Review is the bottleneck — #16 has been green and unmergeable for hours — so splitting would multiply stuck work without making any part easier to read. The four concerns are separate commits if you'd rather have them apart.

## 1. `bill_status.py` — the actions parser (track A1)

Parses `display_ps.asp` into `BillStatus`: paper number, title, flags, committee + referral date, final disposition, governor's action, chaptered law, and the committee docket as `BillAction(date, action, result)` with ISO dates.

**Validated against both real pages:**

| | session 132 LD 1 | session 121 LD 1 |
|---|---|---|
| docket rows | 8 | 3 |
| first → last | `Work Session Held` → `Reported Out / OTP-AM` | `Work Session Held` → `Reported Out / ONTP` |
| disposition | Emergency Enacted, 2025-04-22 | Ought Not to Pass Pursuant To Joint Rule 310, 2003-03-20 |
| chaptered law | ACTPUB Chapter 33 | — |

**The page renders identically for 121 and 132**, so N3 covers all twelve sessions rather than falling back to 128–132. The plan's scale-back trigger — "status pages inconsistent across eras" — does not fire.

Three defects the fixtures caught, all now regression-tested:
- **The docket header is not row 0.** Both tables open with an empty/caption row, so keying on row 0 returned *zero* actions on every page.
- **`#legis_field_head` is not the bill title** despite the name — it wraps the "Choose Another Bill" picker, returning a list of every legislature since the 112th. The title is the `<h2>`.
- **`ld_number` must be zero-padded** (review catch). `parse_filename` yields `"0001"`; the page says `"LD 1"`. `'1' != '0001'` raises nothing — an actions backfill would simply have come out empty and looked like a scraping fault. `status_url` still strips the padding, since the site wants `LD=1`; both directions are tested, and the join test asserts against `parse_filename` itself so it can't drift.

## 2. `legislature_roster.py` — member profiles (issue #13 items 1–2)

Parses `/District{N}` into `MemberProfile`: name, family name, chamber, party, county, district, **every municipality represented**, and the legislative service range.

Validated against three real pages — 48 and 42 enumerated municipalities for districts 2 and 5, plus the whole-county form (`All of Waldo County`) for district 11, which publishes no town list.

**The service line is worth more than expected.** It reads `Legislative Service : Senate 130-132; House 128-129`, so a single current-session page answers for *earlier* sessions:

```
District 5, Russell Black:  House 125-128; Senate 129-132
```

One fetch covers sessions 125–132 across two chambers — reaching into the exact 125–130 ambiguity band item 2 is about. `served_in()` and `chamber_in()` encode that, chamber switch included.

`family_name` takes everything after the given name rather than the last token: bill text names sponsors by surname alone and sitting members have two-word surnames (Talbot Ross), which a last-token rule would fail to match. Party letters expand to the OpenStates spellings, since these entries get matched against those rosters.

**Two limits, documented in the module because they bound the payoff:** these pages exist only for the *current* legislature, so coverage reaches back only as far as a sitting member's service line — sessions 121–124 stay out of reach. And the district pages found so far are Senate seats; House members are published through party caucus pages with a different shape and need their own parser.

## 3. Roster recon

The first recon never reached a member list — 42 of 60 pages went to `billdirectory_ps.asp`, and everything it labelled "roster" was site chrome. Now it seeds the real pages its own link map had surfaced, crawls in **two phases with a reserved budget** (rosters at 40% first), and offers `--focus roster`. One BFS queue starves rosters regardless of seed order, because the bill directory's depth-1 links are queued ahead of theirs and there are hundreds.

## 4. robots.txt capture

The backfill rate was my judgment call; it shouldn't have been if the site stated one. Each run now saves `robots-<host>.txt` plus a parsed `Crawl-delay`/`Request-rate` summary. Result, verbatim:

```
User-agent: *
Disallow: /bills/default_ps.asp
Disallow: /legis/bills/default_ps.asp
Disallow: /bills/search_ps.asp
Disallow: /legis/bills/search_ps.asp
Disallow: /LawMakerWeb
Disallow: /legis/LawMakerWeb
```

**No `Crawl-delay`** — so the throttle stays a judgment call. `display_ps.asp` is allowed, and a test asserts the parser's URL avoids every disallowed path. `/LawMakerWeb` being disallowed is also why the historical-roster probes never ran, which points issue #13 item 1 toward accepting nulls for 121–124.

## Tier-2 review notes

- **Tier decision:** Tier-2. Two new modules under `src/`, one script, tests — no schema fields, no publish path, no `.github/`, no dependencies, no secrets. Both parsers are additive and **unreferenced**; nothing calls them yet.
- **Risk:** low. Pure parsers with zero blast radius until N3 wires them in. The judgment worth your eye is the field sets, since both become schema decisions (Tier-1) when they land — particularly whether `MemberProfile.localities` should persist as a list or be normalized into a locality→member table.
- **Checks:** 47 new tests, 400 passing, ruff clean. Both parsers were run against the real fixture pages, not only synthetic ones — which is how all three `bill_status` defects surfaced.
- **Rollback:** revert the merge. Nothing published, nothing wired in.

## Not in this PR

**A2 backfill is deliberately not started** — it needs the throttle decision (3–4 concurrent sessions vs. narrowing to 128–132), and robots.txt declined to settle it.