### PR TITLE
[Tier-1] docs: standing authorization for Tier-2 reviewer agents

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -35,6 +35,10 @@ Everything else: extraction/matching/scraper code, tests, refactors, docs (other
 
 A human may always review, request changes on, or revert a Tier-2 PR; agent-merge authority is a default, not an exclusion.
 
+**Standing authorization.** The repo owner has authorized the author agent to spawn reviewer subagents to satisfy requirement 2. No per-PR permission is needed. The reviewer must receive the diff and this checklist and must not inherit the author's reasoning history — that separation is the property this requirement is actually after. Be honest about its strength: a reviewer subagent is the same model on the same repo, so it is weaker than a second human or an unrelated session, and it catches what fresh eyes catch rather than what different expertise would.
+
+**Sequencing.** Wait for the automated code review (Copilot) to land and address its findings *before* spawning a reviewer agent. Running them in parallel spends an agent review on a diff that is about to change, and the second review then has to be redone. Order: open PR → CI green → automated review → fix findings → reviewer agent → merge.
+
 ### Escalation rule
 
 If an agent is unsure which tier applies, the PR is Tier 1. A PR that mixes tiers is Tier 1. Reviewers who discover hidden Tier-1 surface (e.g. a "test fix" that alters schema) re-label and stop the merge.


### PR DESCRIPTION
Codifies the authorization you gave, plus the sequencing you recommended. **Tier-1** — it amends `docs/GOVERNANCE.md`, so it needs your merge. Four added lines.

## Why

Tier-2's requirement 2 needs an independent reviewer, and the author agent had no permission to spawn one. So every Tier-2 PR stopped after CI and waited. #16 and #17 both sat green and unmergeable for most of a day, with N3 and the corrected sponsor data behind them — the review requirement, not agent throughput, became the sprint's binding constraint.

Recording it here rather than leaving it as a conversation a future session can't see.

## What it says

**Standing authorization** — no per-PR permission needed. The reviewer must get the diff and the checklist, and must not inherit the author's reasoning history; that separation is the property the requirement is actually after.

**Sequencing** (your call, and the right one): wait for the automated review to land and address its findings *before* spawning a reviewer agent. Running both at once spends an agent review on a diff that's about to change, and it then has to be redone.

> open PR → CI green → automated review → fix findings → reviewer agent → merge

Not hypothetical: Copilot has found a real defect on each of the last three PRs, including one on #17 that would have made the entire actions backfill come out silently empty.

**The limitation, stated plainly.** A reviewer subagent is the same model on the same repo. It catches what fresh eyes catch, not what different expertise would, and it's weaker than a second human or an unrelated session. Better written down than implied — the checklist shouldn't suggest more assurance than it delivers.

## Tier-1 review notes

- **Risk:** procedural, not executable. Its effect is that Tier-2 PRs now merge without you — which is what the tier already intended; this only closes the gap between the policy and what agents were permitted to do. The Tier-1 boundary is untouched: publishes, schema, `.github/`, secrets and dependencies still require you.
- **Rollback:** revert the commit. Agents return to waiting.

Reviewer agents are already running on #16 and #17 under this policy, since Copilot has reviewed both and its findings are addressed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WicqsC1r64bRg1pbAqFsTV)_