### PR TITLE
[Tier-2] feat: bill status backfill at an agreed request rate (node N3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,11 @@ jobs:
         run: uv sync --extra dev
 
       - name: Ruff lint
-        run: uv run ruff check src/ tests/
+        # `scripts/` is in scope deliberately. It was not, and the backfill --
+        # 460 lines that run unattended against a state government server --
+        # was therefore never linted by CI at all. GOVERNANCE.md's Tier-2 bar
+        # says "lint green", which should mean the code that actually ships.
+        run: uv run ruff check src/ tests/ scripts/
 
       - name: Unit tests
         run: uv run pytest tests/ -v -m "not integration"

--- a/.github/workflows/data-run.yml
+++ b/.github/workflows/data-run.yml
@@ -179,7 +179,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
-      contents: write # force-pushes the fixtures/actions branch
+      # Read-only: unlike the recon and status-sample jobs, this one publishes
+      # its output as a workflow artifact and pushes nothing.
+      contents: read
     strategy:
       max-parallel: 3
       fail-fast: false

--- a/.github/workflows/data-run.yml
+++ b/.github/workflows/data-run.yml
@@ -22,6 +22,7 @@ on:
         default: recon-legislature
         options:
           - recon-legislature
+          - backfill-status
           - diagnose-sponsors
           - fetch-status-sample
           - run-matching
@@ -138,6 +139,92 @@ jobs:
         with:
           name: recon
           path: data/recon/
+          if-no-files-found: warn
+
+  # Sprint node N3: fetch and parse every bill's status page for a session,
+  # producing the `actions` legislative-history records.
+  #
+  # THROTTLE. robots.txt for legislature.maine.gov states no Crawl-delay and no
+  # Request-rate, so the rate is our restraint rather than the site's
+  # instruction. One request per second per session, and max-parallel caps how
+  # many sessions run at once: all twelve would mean twelve sustained requests
+  # per second against a state government server. Agreed with the repo owner at
+  # 3-4 concurrent; 3 is set here. Do not raise either without asking.
+  plan-backfill:
+    if: inputs.task == 'backfill-status'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      sessions: ${{ steps.plan.outputs.sessions }}
+    steps:
+      - name: Validate and build the session matrix
+        id: plan
+        env:
+          SESSIONS: ${{ inputs.sessions }}
+        run: |
+          case "$SESSIONS" in
+            "" | *[!0-9\ ]*)
+              echo "::error::sessions must be space-separated digits; got '$SESSIONS'"
+              exit 1
+              ;;
+          esac
+          MATRIX=$(printf '%s' "$SESSIONS" | tr ' ' '\n' | grep -v '^$' \
+            | python3 -c 'import json,sys; print(json.dumps([int(x) for x in sys.stdin.read().split()]))')
+          echo "sessions=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "Matrix: $MATRIX"
+
+  backfill-status:
+    if: inputs.task == 'backfill-status'
+    needs: plan-backfill
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: write # force-pushes the fixtures/actions branch
+    strategy:
+      max-parallel: 3
+      fail-fast: false
+      matrix:
+        session: ${{ fromJSON(needs.plan-backfill.outputs.sessions) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Backfill
+        env:
+          SESSION: ${{ matrix.session }}
+        run: |
+          uv run python scripts/backfill_bill_status.py \
+            --session "$SESSION" \
+            --parquet-source hf://datasets/pem207/maine-bills \
+            --output data/actions
+
+      - name: Summarize
+        if: always()
+        env:
+          SESSION: ${{ matrix.session }}
+        run: |
+          F="data/actions/summary-$SESSION.json"
+          if [ -f "$F" ]; then
+            {
+              echo "### Session $SESSION"
+              echo '```json'
+              cat "$F"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload actions artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: actions-${{ matrix.session }}
+          path: data/actions/
           if-no-files-found: warn
 
   # Issue #13 item 4: session 132 extracts 0.8 sponsor mentions per document

--- a/.github/workflows/data-run.yml
+++ b/.github/workflows/data-run.yml
@@ -168,8 +168,15 @@ jobs:
               exit 1
               ;;
           esac
-          MATRIX=$(printf '%s' "$SESSIONS" | tr ' ' '\n' | grep -v '^$' \
-            | python3 -c 'import json,sys; print(json.dumps([int(x) for x in sys.stdin.read().split()]))')
+          # Deduplicated: a repeated session would otherwise start two jobs
+          # requesting the SAME urls concurrently -- redundant load on the site
+          # and an upload-artifact name collision.
+          MATRIX=$(printf '%s' "$SESSIONS" \
+            | python3 -c 'import json,sys; print(json.dumps(sorted({int(x) for x in sys.stdin.read().split()})))')
+          if [ "$MATRIX" = "[]" ]; then
+            echo "::error::sessions resolved to an empty matrix; got '$SESSIONS'"
+            exit 1
+          fi
           echo "sessions=$MATRIX" >> "$GITHUB_OUTPUT"
           echo "Matrix: $MATRIX"
 
@@ -197,6 +204,17 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
+      # The script is resumable, but a CI job is not: `data/` is gitignored and
+      # every run starts from a fresh checkout, so the resume state only ever
+      # helps someone running the script locally. Re-running a failed job
+      # refetches its session from LD 1.
+      #
+      # Accepted rather than fixed. A session is ~2,000 bills at 1/sec, ~35
+      # minutes against a 120-minute timeout, so a run that needs resuming is a
+      # run that hit a real problem -- and the circuit breaker stops that after
+      # 10 consecutive failures rather than burning the remaining requests.
+      # Restoring the prior artifact would need a cross-run download and an
+      # `actions: read` grant, which is more surface than the case warrants.
       - name: Backfill
         env:
           SESSION: ${{ matrix.session }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ line-length = 100
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
 
+[tool.ruff.lint.per-file-ignores]
+# A markdown report template: the long lines are prose inside a string, where a
+# line break would change the rendered output rather than just the source.
+"scripts/generate_final_summary.py" = ["E501"]
+
 [dependency-groups]
 dev = [
     "jupyter>=1.1.1",

--- a/scripts/backfill_bill_status.py
+++ b/scripts/backfill_bill_status.py
@@ -1,0 +1,257 @@
+"""Fetch and parse bill status pages for a session (sprint node N3).
+
+Produces the `actions` dataset config: one record per bill carrying its
+legislative history — committee docket, referral, final disposition, governor's
+action, chaptered law.
+
+**Enumeration comes from the published dataset, not from the site.** Every LD
+number for a session is already in the parquet we publish, so the bill directory
+(`billdirectory_ps.asp`, ~13 paged fetches per session) never has to be
+crawled. Fewer requests, and the LD set is exactly the one the actions table
+must join against — enumerating from the site could drift from it.
+
+**Request rate.** robots.txt for legislature.maine.gov states no `Crawl-delay`
+and no `Request-rate`, so the rate is our judgment, not the site's instruction:
+one request per second per session, and the workflow caps concurrent sessions.
+Twelve sessions at once would mean twelve sustained requests per second against
+a state government server, which is not a reasonable thing to do unasked.
+
+Resumable: an existing output file is read back and its bills skipped, so an
+interrupted run costs only what it had not yet fetched.
+
+Usage:
+    uv run python scripts/backfill_bill_status.py \\
+        --session 132 \\
+        --parquet-source hf://datasets/pem207/maine-bills \\
+        --output data/actions
+"""
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+from maine_bills.bill_status import BillStatus, normalize_ld, parse_status_page, status_url
+
+logger = logging.getLogger("backfill_bill_status")
+
+USER_AGENT = (
+    "maine-bills-status/1.0 "
+    "(+https://github.com/PhilipMathieu/maine-bills; research dataset tooling)"
+)
+REQUEST_TIMEOUT = 30
+DEFAULT_DELAY = 1.0
+
+# Retry only what a retry can fix. A 404 means the LD has no status page and
+# will still have none on a second attempt.
+RETRY_STATUSES = {429, 500, 502, 503, 504}
+MAX_ATTEMPTS = 3
+
+
+def session_ld_numbers(parquet_source: str, session: int) -> list[str]:
+    """Every distinct LD number published for a session, in order."""
+    import importlib.util
+
+    report_path = Path(__file__).with_name("run_matching_report.py")
+    spec = importlib.util.spec_from_file_location("_matching_report", report_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - packaging error
+        raise ImportError(f"Cannot load the parquet loader from {report_path}")
+    report = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(report)
+
+    df = report.load_session_bills(parquet_source, session)
+    # Amendments share their parent bill's LD, so distinct LDs are what we want:
+    # the status page describes the bill, not each printed document.
+    return sorted({normalize_ld(ld) for ld in df["ld_number"].dropna().unique()})
+
+
+def fetch_status(
+    http: requests.Session, session: int, ld: str, delay: float
+) -> tuple[str | None, int | None]:
+    """Fetch one status page. Returns (html, status_code); html is None on failure."""
+    url = status_url(session, ld)
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            res = http.get(url, timeout=REQUEST_TIMEOUT)
+        except requests.RequestException as e:
+            logger.warning(f"LD {ld}: {type(e).__name__}: {e} (attempt {attempt})")
+            time.sleep(delay * attempt)
+            continue
+
+        if res.status_code == 200:
+            return res.text, 200
+        if res.status_code not in RETRY_STATUSES:
+            return None, res.status_code
+
+        logger.warning(f"LD {ld}: HTTP {res.status_code} (attempt {attempt})")
+        # Back off proportionally rather than hammering a server already
+        # signalling distress.
+        time.sleep(delay * attempt * 2)
+
+    return None, None
+
+
+def to_record(status: BillStatus) -> dict:
+    """Flatten a BillStatus for parquet/JSON, keyed to join the bills table."""
+    return {
+        "session": status.session,
+        "ld_number": status.ld_number,
+        "paper": status.paper,
+        "title": status.title,
+        "flags": status.flags,
+        "committee": status.committee,
+        "referred_date": status.referred_date,
+        "final_disposition": status.final_disposition,
+        "final_disposition_date": status.final_disposition_date,
+        "governor_action": status.governor_action,
+        "governor_action_date": status.governor_action_date,
+        "chaptered_law": status.chaptered_law,
+        "actions": [
+            {"date": a.date, "action": a.action, "result": a.result, "raw_date": a.raw_date}
+            for a in status.actions
+        ],
+        "action_count": len(status.actions),
+        "source_url": status.source_url,
+    }
+
+
+def is_status_page(status: BillStatus) -> bool:
+    """Whether a parsed page is actually a bill's status page.
+
+    Every real one carries the paper number in its ``<title>`` and the act title
+    in its ``<h2>``, whatever else is missing — a bill can legitimately have no
+    docket rows and no disposition. An error or redirect page has neither.
+    """
+    return bool(status.paper or status.title)
+
+
+def load_existing(path: Path) -> dict[str, dict]:
+    """Records already fetched, keyed by LD, so a rerun resumes."""
+    if not path.exists():
+        return {}
+    try:
+        return {r["ld_number"]: r for r in json.loads(path.read_text())}
+    except (json.JSONDecodeError, KeyError, TypeError):
+        logger.warning(f"{path} is unreadable; starting fresh")
+        return {}
+
+
+def backfill(
+    session: int,
+    ld_numbers: list[str],
+    out_path: Path,
+    delay: float,
+    limit: int | None = None,
+    checkpoint_every: int = 50,
+) -> dict:
+    """Fetch and parse every LD's status page, writing progress as it goes."""
+    records = load_existing(out_path)
+    todo = [ld for ld in ld_numbers if ld not in records]
+    if limit is not None:
+        todo = todo[:limit]
+
+    logger.info(
+        f"Session {session}: {len(ld_numbers)} LDs, {len(records)} already fetched, "
+        f"{len(todo)} to go at {delay}s/request (~{len(todo) * delay / 60:.0f} min)"
+    )
+
+    missing, failed = [], []
+    for i, ld in enumerate(todo, start=1):
+        html, code = fetch_status(http_session(), session, ld, delay)
+        if html is None:
+            (missing if code == 404 else failed).append(ld)
+        else:
+            try:
+                status = parse_status_page(html, session=session, ld=ld)
+            except ValueError as e:
+                # A page that does not parse is a data problem worth seeing, not
+                # a reason to abandon the remaining bills.
+                logger.warning(f"LD {ld}: unparseable ({e})")
+                failed.append(ld)
+            else:
+                if not is_status_page(status):
+                    # Passing session/ld as overrides means parse_status_page
+                    # cannot raise on an error page — it has the identifiers it
+                    # needs from us. Without this check the run would happily
+                    # record an all-null row for every 200-that-isn't-a-bill and
+                    # report success.
+                    logger.warning(f"LD {ld}: 200 but not a status page; skipping")
+                    failed.append(ld)
+                else:
+                    records[ld] = to_record(status)
+
+        if i % checkpoint_every == 0:
+            write_output(out_path, records)
+            logger.info(f"  {i}/{len(todo)} ({len(records)} records)")
+        time.sleep(delay)
+
+    write_output(out_path, records)
+    summary = {
+        "session": session,
+        "lds_total": len(ld_numbers),
+        "records": len(records),
+        "no_status_page": len(missing),
+        "failed": len(failed),
+        "failed_lds": failed[:50],
+        "actions_total": sum(r["action_count"] for r in records.values()),
+    }
+    logger.info(
+        f"Session {session}: {summary['records']} records, "
+        f"{summary['actions_total']} actions, {summary['no_status_page']} without a page, "
+        f"{summary['failed']} failed"
+    )
+    return summary
+
+
+_HTTP: requests.Session | None = None
+
+
+def http_session() -> requests.Session:
+    global _HTTP
+    if _HTTP is None:
+        _HTTP = requests.Session()
+        _HTTP.headers.update({"User-Agent": USER_AGENT})
+    return _HTTP
+
+
+def write_output(path: Path, records: dict[str, dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(sorted(records.values(), key=lambda r: r["ld_number"]), indent=1))
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--session", type=int, required=True)
+    parser.add_argument("--parquet-source", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=DEFAULT_DELAY,
+        help="Seconds between requests. robots.txt states no Crawl-delay, so this "
+        "is our own restraint; do not lower it without a reason.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Fetch at most N bills (smoke test)"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
+    args = parse_args(argv)
+
+    ld_numbers = session_ld_numbers(args.parquet_source, args.session)
+    out_path = args.output / f"actions-{args.session}.json"
+    summary = backfill(args.session, ld_numbers, out_path, args.delay, args.limit)
+
+    (args.output / f"summary-{args.session}.json").write_text(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill_bill_status.py
+++ b/scripts/backfill_bill_status.py
@@ -122,9 +122,12 @@ def to_record(status: BillStatus) -> dict:
 def is_status_page(status: BillStatus) -> bool:
     """Whether a parsed page is actually a bill's status page.
 
-    Every real one carries the paper number in its ``<title>`` and the act title
-    in its ``<h2>``, whatever else is missing — a bill can legitimately have no
-    docket rows and no disposition. An error or redirect page has neither.
+    Deliberately lenient: it rejects only a page carrying *neither* the paper
+    number (from ``<title>``) nor the act title (from ``<h2>``). A real status
+    page always has at least one, whatever else is missing — a bill can
+    legitimately have no docket rows and no disposition — while an error or
+    redirect page has neither. Requiring both would discard real bills whose
+    page omits one of the two.
     """
     return bool(status.paper or status.title)
 
@@ -140,6 +143,26 @@ def load_existing(path: Path) -> dict[str, dict]:
         return {}
 
 
+def missing_path_for(out_path: Path) -> Path:
+    """Sidecar listing LDs the site has no status page for.
+
+    Kept beside the records rather than inside them so the output file stays a
+    clean actions table with no null-filled placeholder rows.
+    """
+    return out_path.with_name(f"{out_path.stem}-missing.json")
+
+
+def load_missing(path: Path) -> set[str]:
+    """LDs already known to 404, so a resumed run does not ask again."""
+    if not path.exists():
+        return set()
+    try:
+        return set(json.loads(path.read_text()))
+    except (json.JSONDecodeError, TypeError):
+        logger.warning(f"{path} is unreadable; will refetch missing LDs")
+        return set()
+
+
 def backfill(
     session: int,
     ld_numbers: list[str],
@@ -147,23 +170,35 @@ def backfill(
     delay: float,
     limit: int | None = None,
     checkpoint_every: int = 50,
+    recheck_missing: bool = False,
 ) -> dict:
     """Fetch and parse every LD's status page, writing progress as it goes."""
     records = load_existing(out_path)
-    todo = [ld for ld in ld_numbers if ld not in records]
+    miss_path = missing_path_for(out_path)
+    # A 404 is definitive — the site has no page for that LD and will not grow
+    # one mid-run — so it is persisted and skipped on resume. Server errors are
+    # deliberately NOT persisted: those are transient, and retrying them is the
+    # main thing a resumed run is for.
+    missing: set[str] = set() if recheck_missing else load_missing(miss_path)
+
+    todo = [ld for ld in ld_numbers if ld not in records and ld not in missing]
     if limit is not None:
         todo = todo[:limit]
 
     logger.info(
         f"Session {session}: {len(ld_numbers)} LDs, {len(records)} already fetched, "
+        f"{len(missing)} known to have no page, "
         f"{len(todo)} to go at {delay}s/request (~{len(todo) * delay / 60:.0f} min)"
     )
 
-    missing, failed = [], []
+    failed: list[str] = []
     for i, ld in enumerate(todo, start=1):
         html, code = fetch_status(http_session(), session, ld, delay)
         if html is None:
-            (missing if code == 404 else failed).append(ld)
+            if code == 404:
+                missing.add(ld)
+            else:
+                failed.append(ld)
         else:
             try:
                 status = parse_status_page(html, session=session, ld=ld)
@@ -186,10 +221,12 @@ def backfill(
 
         if i % checkpoint_every == 0:
             write_output(out_path, records)
+            write_missing(miss_path, missing)
             logger.info(f"  {i}/{len(todo)} ({len(records)} records)")
         time.sleep(delay)
 
     write_output(out_path, records)
+    write_missing(miss_path, missing)
     summary = {
         "session": session,
         "lds_total": len(ld_numbers),
@@ -223,6 +260,11 @@ def write_output(path: Path, records: dict[str, dict]) -> None:
     path.write_text(json.dumps(sorted(records.values(), key=lambda r: r["ld_number"]), indent=1))
 
 
+def write_missing(path: Path, missing: set[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(sorted(missing), indent=1))
+
+
 def parse_args(argv=None):
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--session", type=int, required=True)
@@ -238,6 +280,13 @@ def parse_args(argv=None):
     parser.add_argument(
         "--limit", type=int, default=None, help="Fetch at most N bills (smoke test)"
     )
+    parser.add_argument(
+        "--recheck-missing",
+        action="store_true",
+        help="Retry LDs previously recorded as having no status page. Needed only "
+        "for a session still in progress, where a newly filed bill can gain a page "
+        "after we looked.",
+    )
     return parser.parse_args(argv)
 
 
@@ -247,7 +296,14 @@ def main(argv=None) -> int:
 
     ld_numbers = session_ld_numbers(args.parquet_source, args.session)
     out_path = args.output / f"actions-{args.session}.json"
-    summary = backfill(args.session, ld_numbers, out_path, args.delay, args.limit)
+    summary = backfill(
+        args.session,
+        ld_numbers,
+        out_path,
+        args.delay,
+        args.limit,
+        recheck_missing=args.recheck_missing,
+    )
 
     (args.output / f"summary-{args.session}.json").write_text(json.dumps(summary, indent=2))
     return 0

--- a/scripts/backfill_bill_status.py
+++ b/scripts/backfill_bill_status.py
@@ -84,6 +84,12 @@ MAX_CONSECUTIVE_MISSING = 50
 # failed to fire inside the job timeout.
 RETRY_AFTER_ABORT = 120.0
 
+# How many failures a single end-of-run retry pass will take on. Sized to catch
+# the transient tail -- the smoke run finished sessions 132 and 121 with exactly
+# 7 read timeouts each out of ~2,000 -- while refusing to re-drive a session
+# that failed in bulk, which is what the breakers are for.
+MAX_RETRY_PASS = 50
+
 
 class SiteRefusing(Exception):
     """The site asked us to go away for longer than this run should wait."""
@@ -318,32 +324,37 @@ def backfill(
     aborted = False
     abort_reason: str | None = None
 
+    def fetch_one(ld: str) -> str:
+        """Fetch, classify and record one bill. Returns its outcome.
+
+        Raises SiteRefusing, which the caller turns into an abort.
+        """
+        html, code = fetch_status(http_session(), session, ld, delay)
+        if html is None:
+            # Retained for correctness on a host that does hard-404, though
+            # legislature.maine.gov does not -- see NOT_FOUND_MARKER.
+            return "missing" if code == 404 else "failed"
+        try:
+            status = parse_status_page(html, session=session, ld=ld)
+        except ValueError as e:
+            # A page that does not parse is a data problem worth seeing, not
+            # a reason to abandon the remaining bills.
+            logger.warning(f"LD {ld}: unparseable ({e})")
+            return "failed"
+        outcome = classify_page(html, status)
+        if outcome == "ok":
+            records[ld] = to_record(status)
+        elif outcome == "unrecognized":
+            logger.warning(f"LD {ld}: 200 but not a recognizable page")
+        return outcome
+
     for i, ld in enumerate(todo, start=1):
         try:
-            html, code = fetch_status(http_session(), session, ld, delay)
+            outcome = fetch_one(ld)
         except SiteRefusing as e:
             logger.error(f"Session {session}: {e}; stopping after {i - 1}/{len(todo)}")
             aborted, abort_reason = True, str(e)
             break
-        outcome = "failed"
-
-        if html is None:
-            # Retained for correctness on a host that does hard-404, though
-            # legislature.maine.gov does not -- see NOT_FOUND_MARKER.
-            outcome = "missing" if code == 404 else "failed"
-        else:
-            try:
-                status = parse_status_page(html, session=session, ld=ld)
-            except ValueError as e:
-                # A page that does not parse is a data problem worth seeing, not
-                # a reason to abandon the remaining bills.
-                logger.warning(f"LD {ld}: unparseable ({e})")
-            else:
-                outcome = classify_page(html, status)
-                if outcome == "ok":
-                    records[ld] = to_record(status)
-                elif outcome == "unrecognized":
-                    logger.warning(f"LD {ld}: 200 but not a recognizable page")
 
         if outcome == "ok":
             missing.discard(ld)
@@ -384,6 +395,39 @@ def backfill(
             write_missing(miss_path, missing)
             logger.info(f"  {i}/{len(todo)} ({len(records)} records)")
         time.sleep(delay)
+
+    # One sweep back over the failures before giving up on them.
+    #
+    # The smoke run made the case: sessions 132 and 121 each finished with 2034
+    # of 2041 and 1957 of 1965, failing only on a handful of read timeouts --
+    # and each reported incomplete and exited 1 over them. Because a CI job
+    # cannot resume, recovering those seven would have meant refetching two
+    # thousand pages. Seven requests here instead is both the cheaper and the
+    # more considerate answer.
+    #
+    # Bounded deliberately: one pass, and only when the failures are few enough
+    # to look transient. A session that failed in bulk has something actually
+    # wrong with it, and retrying all of it is the behaviour the breakers exist
+    # to prevent.
+    if failed and not aborted and len(failed) <= MAX_RETRY_PASS:
+        retrying, failed = failed, []
+        logger.info(f"Session {session}: retrying {len(retrying)} failed bills")
+        for ld in retrying:
+            try:
+                outcome = fetch_one(ld)
+            except SiteRefusing as e:
+                logger.error(f"Session {session}: {e} (during retry pass)")
+                aborted, abort_reason = True, str(e)
+                failed.extend(retrying[retrying.index(ld) :])
+                break
+            if outcome == "missing":
+                missing.add(ld)
+            elif outcome != "ok":
+                failed.append(ld)
+            time.sleep(delay)
+        logger.info(
+            f"Session {session}: retry recovered {len(retrying) - len(failed)} of {len(retrying)}"
+        )
 
     write_output(out_path, records)
     write_missing(miss_path, missing)

--- a/scripts/backfill_bill_status.py
+++ b/scripts/backfill_bill_status.py
@@ -51,6 +51,25 @@ DEFAULT_DELAY = 1.0
 RETRY_STATUSES = {429, 500, 502, 503, 504}
 MAX_ATTEMPTS = 3
 
+# Stop the session after this many consecutive failures. Per-LD retry alone is
+# not enough: if the site starts refusing -- a WAF block, a rate limiter, an
+# outage -- every remaining LD is still attempted at the full request rate, so a
+# 2,000-bill session becomes 2,000 futile requests against a server that has
+# already said stop, times however many sessions run at once. The point of this
+# script's throttle is not to be a burden; continuing past a sustained refusal
+# would be exactly that.
+MAX_CONSECUTIVE_FAILURES = 10
+
+# The site does NOT return 404 for a bill that does not exist. It answers 200
+# with a normal-looking page whose only tell is this heading. Verified against
+# LD=9999 and LD=99999 on session 132, and every real page sampled across
+# sessions 121-132 carries a paper number while this one does not.
+#
+# This matters more than it looks: it means the HTTP-404 path below is
+# effectively dead code on this host, and every nonexistent LD arrives as a 200
+# that must be classified by shape instead.
+NOT_FOUND_MARKER = "Cannot find requested paper"
+
 
 def session_ld_numbers(parquet_source: str, session: int) -> list[str]:
     """Every distinct LD number published for a session, in order."""
@@ -69,11 +88,34 @@ def session_ld_numbers(parquet_source: str, session: int) -> list[str]:
     return sorted({normalize_ld(ld) for ld in df["ld_number"].dropna().unique()})
 
 
+def retry_after(response, default: float) -> float:
+    """Honor a ``Retry-After`` header, capped so a silly value cannot stall us.
+
+    Only the delta-seconds form is handled; the HTTP-date form is rare and a
+    miss just falls back to our own backoff.
+    """
+    raw = getattr(response, "headers", {}).get("Retry-After")
+    if not raw:
+        return default
+    try:
+        return min(max(float(raw), 0.0), 300.0)
+    except (TypeError, ValueError):
+        return default
+
+
 def fetch_status(
     http: requests.Session, session: int, ld: str, delay: float
 ) -> tuple[str | None, int | None]:
     """Fetch one status page. Returns (html, status_code); html is None on failure."""
-    url = status_url(session, ld)
+    try:
+        url = status_url(session, ld)
+    except ValueError as e:
+        # normalize_ld int-casts. Unreachable through the parquet enumeration
+        # (schema.FILENAME_PATTERN constrains the number to \d+), but a bad LD
+        # here would otherwise kill the whole session having written nothing.
+        logger.warning(f"LD {ld!r}: not a usable LD number ({e})")
+        return None, None
+
     for attempt in range(1, MAX_ATTEMPTS + 1):
         try:
             res = http.get(url, timeout=REQUEST_TIMEOUT)
@@ -89,8 +131,9 @@ def fetch_status(
 
         logger.warning(f"LD {ld}: HTTP {res.status_code} (attempt {attempt})")
         # Back off proportionally rather than hammering a server already
-        # signalling distress.
-        time.sleep(delay * attempt * 2)
+        # signalling distress -- and when it has told us exactly how long to
+        # wait, wait that long instead of guessing.
+        time.sleep(retry_after(res, delay * attempt * 2))
 
     return None, None
 
@@ -122,14 +165,38 @@ def to_record(status: BillStatus) -> dict:
 def is_status_page(status: BillStatus) -> bool:
     """Whether a parsed page is actually a bill's status page.
 
-    Deliberately lenient: it rejects only a page carrying *neither* the paper
-    number (from ``<title>``) nor the act title (from ``<h2>``). A real status
-    page always has at least one, whatever else is missing — a bill can
-    legitimately have no docket rows and no disposition — while an error or
-    redirect page has neither. Requiring both would discard real bills whose
-    page omits one of the two.
+    Keys on the paper number specifically. An earlier version accepted ``paper
+    or title``, which the site's not-found page defeats: ``_parse_bill_title``
+    falls back to the longest heading, so "Cannot find requested paper, please
+    provide a Paper or LD number in the box to the left." was read as an act
+    title and the page recorded as a real bill. Every nonexistent LD in every
+    session would have landed in the actions table titled with an error
+    message, and the run would have reported complete success.
+
+    Every real page sampled across sessions 121-132 carries a paper number
+    (SP 29, HP 1287, ...) whatever else is missing — a bill can legitimately
+    have no docket rows and no disposition — and the not-found page carries
+    none.
     """
-    return bool(status.paper or status.title)
+    return bool(status.paper)
+
+
+def classify_page(html: str, status: BillStatus) -> str:
+    """One of "ok", "missing", or "unrecognized".
+
+    The distinction that matters is definitive-vs-transient. "missing" is the
+    site telling us this LD does not exist, which is permanent and worth
+    remembering. "unrecognized" is a 200 we cannot account for — a WAF
+    challenge, an outage page, a redirect to a portal — which may well clear on
+    a later run, so it counts as a failure and is never persisted as missing.
+    Collapsing the two would let a transient block be recorded as "this bill
+    does not exist" and never asked about again.
+    """
+    if is_status_page(status):
+        return "ok"
+    if NOT_FOUND_MARKER in html:
+        return "missing"
+    return "unrecognized"
 
 
 def load_existing(path: Path) -> dict[str, dict]:
@@ -175,13 +242,21 @@ def backfill(
     """Fetch and parse every LD's status page, writing progress as it goes."""
     records = load_existing(out_path)
     miss_path = missing_path_for(out_path)
-    # A 404 is definitive — the site has no page for that LD and will not grow
-    # one mid-run — so it is persisted and skipped on resume. Server errors are
+    # "No such bill" is definitive — the site will not grow a page for it
+    # mid-run — so it is persisted and skipped on resume. Failures are
     # deliberately NOT persisted: those are transient, and retrying them is the
     # main thing a resumed run is for.
-    missing: set[str] = set() if recheck_missing else load_missing(miss_path)
+    #
+    # Under --recheck-missing the known set is still LOADED, and entries are
+    # removed only when the site is observed to answer for them. Starting from
+    # an empty set instead means a recheck that does not finish -- a --limit, a
+    # crash, the job timeout -- rewrites the sidecar with only what it happened
+    # to re-reach and forgets the rest.
+    known_missing = load_missing(miss_path)
+    missing: set[str] = set(known_missing)
 
-    todo = [ld for ld in ld_numbers if ld not in records and ld not in missing]
+    skip = set(records) if recheck_missing else set(records) | missing
+    todo = [ld for ld in ld_numbers if ld not in skip]
     if limit is not None:
         todo = todo[:limit]
 
@@ -192,13 +267,19 @@ def backfill(
     )
 
     failed: list[str] = []
+    consecutive_failures = 0
+    aborted = False
+    attempted = 0
+
     for i, ld in enumerate(todo, start=1):
+        attempted = i
         html, code = fetch_status(http_session(), session, ld, delay)
+        outcome = "failed"
+
         if html is None:
-            if code == 404:
-                missing.add(ld)
-            else:
-                failed.append(ld)
+            # Retained for correctness on a host that does hard-404, though
+            # legislature.maine.gov does not -- see NOT_FOUND_MARKER.
+            outcome = "missing" if code == 404 else "failed"
         else:
             try:
                 status = parse_status_page(html, session=session, ld=ld)
@@ -206,18 +287,32 @@ def backfill(
                 # A page that does not parse is a data problem worth seeing, not
                 # a reason to abandon the remaining bills.
                 logger.warning(f"LD {ld}: unparseable ({e})")
-                failed.append(ld)
             else:
-                if not is_status_page(status):
-                    # Passing session/ld as overrides means parse_status_page
-                    # cannot raise on an error page — it has the identifiers it
-                    # needs from us. Without this check the run would happily
-                    # record an all-null row for every 200-that-isn't-a-bill and
-                    # report success.
-                    logger.warning(f"LD {ld}: 200 but not a status page; skipping")
-                    failed.append(ld)
-                else:
+                outcome = classify_page(html, status)
+                if outcome == "ok":
                     records[ld] = to_record(status)
+                elif outcome == "unrecognized":
+                    logger.warning(f"LD {ld}: 200 but not a recognizable page")
+
+        if outcome == "ok":
+            missing.discard(ld)
+            consecutive_failures = 0
+        elif outcome == "missing":
+            missing.add(ld)
+            # Not a failure: the site answered us plainly. It must not count
+            # toward the breaker, or a session with many gaps would abort.
+            consecutive_failures = 0
+        else:
+            failed.append(ld)
+            consecutive_failures += 1
+            if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                logger.error(
+                    f"Session {session}: {consecutive_failures} consecutive failures; "
+                    f"stopping after {i}/{len(todo)}. The site is not answering, and "
+                    f"continuing would be {len(todo) - i} more requests at it."
+                )
+                aborted = True
+                break
 
         if i % checkpoint_every == 0:
             write_output(out_path, records)
@@ -227,19 +322,28 @@ def backfill(
 
     write_output(out_path, records)
     write_missing(miss_path, missing)
+    # A partial actions table is shape-identical to a complete one, so the
+    # summary has to say which it is. Without `complete` and `not_attempted`,
+    # a run that aborted at LD 40 of 2,000 produces a file that looks like a
+    # small session.
+    not_attempted = max(0, len(todo) - attempted)
     summary = {
         "session": session,
         "lds_total": len(ld_numbers),
         "records": len(records),
         "no_status_page": len(missing),
         "failed": len(failed),
-        "failed_lds": failed[:50],
+        "failed_lds": failed,
+        "not_attempted": not_attempted,
+        "aborted": aborted,
+        "complete": not aborted and not_attempted == 0 and not failed,
         "actions_total": sum(r["action_count"] for r in records.values()),
     }
     logger.info(
         f"Session {session}: {summary['records']} records, "
         f"{summary['actions_total']} actions, {summary['no_status_page']} without a page, "
-        f"{summary['failed']} failed"
+        f"{summary['failed']} failed, {not_attempted} not attempted"
+        f"{' (ABORTED)' if aborted else ''}"
     )
     return summary
 
@@ -255,14 +359,26 @@ def http_session() -> requests.Session:
     return _HTTP
 
 
-def write_output(path: Path, records: dict[str, dict]) -> None:
+def write_json(path: Path, payload) -> None:
+    """Write atomically, so a kill mid-checkpoint cannot truncate the file.
+
+    A bare ``write_text`` leaves a half-written file if the process dies during
+    it, and ``load_existing`` treats an unparseable file as "start fresh" —
+    which at session scale means silently re-requesting ~2,000 pages that were
+    already fetched.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(sorted(records.values(), key=lambda r: r["ld_number"]), indent=1))
+    tmp = path.with_suffix(f"{path.suffix}.tmp")
+    tmp.write_text(json.dumps(payload, indent=1))
+    tmp.replace(path)
+
+
+def write_output(path: Path, records: dict[str, dict]) -> None:
+    write_json(path, sorted(records.values(), key=lambda r: r["ld_number"]))
 
 
 def write_missing(path: Path, missing: set[str]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(sorted(missing), indent=1))
+    write_json(path, sorted(missing))
 
 
 def parse_args(argv=None):
@@ -296,16 +412,46 @@ def main(argv=None) -> int:
 
     ld_numbers = session_ld_numbers(args.parquet_source, args.session)
     out_path = args.output / f"actions-{args.session}.json"
-    summary = backfill(
-        args.session,
-        ld_numbers,
-        out_path,
-        args.delay,
-        args.limit,
-        recheck_missing=args.recheck_missing,
-    )
+    summary_path = args.output / f"summary-{args.session}.json"
 
-    (args.output / f"summary-{args.session}.json").write_text(json.dumps(summary, indent=2))
+    try:
+        summary = backfill(
+            args.session,
+            ld_numbers,
+            out_path,
+            args.delay,
+            args.limit,
+            recheck_missing=args.recheck_missing,
+        )
+    except BaseException as e:
+        # Including KeyboardInterrupt and the job timeout's SIGTERM: an
+        # interrupted run must still say it was interrupted. Without this the
+        # artifact holds a partial actions table and no summary at all, which
+        # is indistinguishable from a small complete session.
+        write_json(
+            summary_path,
+            {
+                "session": args.session,
+                "lds_total": len(ld_numbers),
+                "complete": False,
+                "aborted": True,
+                "error": f"{type(e).__name__}: {e}",
+            },
+        )
+        raise
+
+    write_json(summary_path, summary)
+
+    # Exit non-zero on an incomplete run. Returning 0 unconditionally meant a
+    # session that was blocked at request one produced a green check, an empty
+    # artifact, and a summary nobody is obliged to read — indistinguishable
+    # from a successful backfill.
+    if not summary["complete"]:
+        logger.error(
+            f"Session {args.session} incomplete: {summary['failed']} failed, "
+            f"{summary['not_attempted']} not attempted"
+        )
+        return 1
     return 0
 
 

--- a/scripts/backfill_bill_status.py
+++ b/scripts/backfill_bill_status.py
@@ -29,6 +29,8 @@ Usage:
 import argparse
 import json
 import logging
+import os
+import signal
 import sys
 import time
 from pathlib import Path
@@ -59,6 +61,24 @@ MAX_ATTEMPTS = 3
 # script's throttle is not to be a burden; continuing past a sustained refusal
 # would be exactly that.
 MAX_CONSECUTIVE_FAILURES = 10
+
+# A long enough run of "no such bill" is not a sparse session, it is a systemic
+# problem. Enumeration comes from the parquet, so every LD we ask about is one
+# we already hold a document for -- a missing status page is anomalous BY
+# CONSTRUCTION. A wrong session number is the concrete case: the site answers
+# the identical not-found body for every LD, which without this guard produces
+# 2,000 requests, an empty actions table, and a green check.
+MAX_CONSECUTIVE_MISSING = 50
+
+# A Retry-After longer than this ends the session rather than being slept
+# through. Sitting out a 300s wait three times per bill is how the breaker
+# failed to fire inside the job timeout.
+RETRY_AFTER_ABORT = 120.0
+
+
+class SiteRefusing(Exception):
+    """The site asked us to go away for longer than this run should wait."""
+
 
 # The site does NOT return 404 for a bill that does not exist. It answers 200
 # with a normal-looking page whose only tell is this heading. Verified against
@@ -117,11 +137,17 @@ def fetch_status(
         return None, None
 
     for attempt in range(1, MAX_ATTEMPTS + 1):
+        last = attempt == MAX_ATTEMPTS
         try:
             res = http.get(url, timeout=REQUEST_TIMEOUT)
         except requests.RequestException as e:
             logger.warning(f"LD {ld}: {type(e).__name__}: {e} (attempt {attempt})")
-            time.sleep(delay * attempt)
+            # Never sleep after the final attempt: the wait is a backoff before
+            # a retry, and there is no retry left. Sleeping anyway is pure
+            # dead time, and with a long Retry-After it was enough to keep the
+            # circuit breaker from ever firing inside the job timeout.
+            if not last:
+                time.sleep(delay * attempt)
             continue
 
         if res.status_code == 200:
@@ -129,11 +155,22 @@ def fetch_status(
         if res.status_code not in RETRY_STATUSES:
             return None, res.status_code
 
+        wait = retry_after(res, delay * attempt * 2)
+        if wait > RETRY_AFTER_ABORT:
+            # The server has named a wait longer than we are willing to sit
+            # through. Waiting it out would park the job; ignoring it would be
+            # rude. Stopping is the honest reading of what it asked for.
+            raise SiteRefusing(
+                f"HTTP {res.status_code} with Retry-After {wait:.0f}s on LD {ld}; "
+                f"the site is asking us to back off for longer than this run should wait"
+            )
+
         logger.warning(f"LD {ld}: HTTP {res.status_code} (attempt {attempt})")
         # Back off proportionally rather than hammering a server already
         # signalling distress -- and when it has told us exactly how long to
         # wait, wait that long instead of guessing.
-        time.sleep(retry_after(res, delay * attempt * 2))
+        if not last:
+            time.sleep(wait)
 
     return None, None
 
@@ -268,12 +305,17 @@ def backfill(
 
     failed: list[str] = []
     consecutive_failures = 0
+    consecutive_missing = 0
     aborted = False
-    attempted = 0
+    abort_reason: str | None = None
 
     for i, ld in enumerate(todo, start=1):
-        attempted = i
-        html, code = fetch_status(http_session(), session, ld, delay)
+        try:
+            html, code = fetch_status(http_session(), session, ld, delay)
+        except SiteRefusing as e:
+            logger.error(f"Session {session}: {e}; stopping after {i - 1}/{len(todo)}")
+            aborted, abort_reason = True, str(e)
+            break
         outcome = "failed"
 
         if html is None:
@@ -296,14 +338,28 @@ def backfill(
 
         if outcome == "ok":
             missing.discard(ld)
-            consecutive_failures = 0
+            consecutive_failures = consecutive_missing = 0
         elif outcome == "missing":
             missing.add(ld)
             # Not a failure: the site answered us plainly. It must not count
-            # toward the breaker, or a session with many gaps would abort.
+            # toward the failure breaker, or a session with genuine gaps would
+            # abort. It gets its own, looser breaker instead.
             consecutive_failures = 0
+            consecutive_missing += 1
+            if consecutive_missing >= MAX_CONSECUTIVE_MISSING:
+                logger.error(
+                    f"Session {session}: {consecutive_missing} consecutive bills with no "
+                    f"status page; stopping after {i}/{len(todo)}. Every LD here comes "
+                    f"from the published parquet, so this many in a row means the "
+                    f"session number is wrong or the site has changed, not that the "
+                    f"bills are absent."
+                )
+                aborted = True
+                abort_reason = f"{consecutive_missing} consecutive bills with no status page"
+                break
         else:
             failed.append(ld)
+            consecutive_missing = 0
             consecutive_failures += 1
             if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
                 logger.error(
@@ -312,6 +368,7 @@ def backfill(
                     f"continuing would be {len(todo) - i} more requests at it."
                 )
                 aborted = True
+                abort_reason = f"{consecutive_failures} consecutive failures"
                 break
 
         if i % checkpoint_every == 0:
@@ -330,6 +387,10 @@ def backfill(
     # `todo` made a --limit smoke test report complete: the run finishes
     # everything it was asked for while thousands of bills remain unfetched.
     outstanding = [ld for ld in ld_numbers if ld not in records and ld not in missing]
+    # `records` must be non-empty. Without it, a run where EVERY bill came back
+    # "no such bill" has nothing outstanding and reports success: a wrong
+    # session number does exactly that, since the site answers the identical
+    # not-found body for every LD. Green check, empty actions table.
     summary = {
         "session": session,
         "lds_total": len(ld_numbers),
@@ -339,7 +400,8 @@ def backfill(
         "failed_lds": failed,
         "not_attempted": len(outstanding),
         "aborted": aborted,
-        "complete": not aborted and not outstanding,
+        "abort_reason": abort_reason,
+        "complete": not aborted and not outstanding and bool(records),
         "actions_total": sum(r["action_count"] for r in records.values()),
     }
     logger.info(
@@ -371,7 +433,12 @@ def write_json(path: Path, payload) -> None:
     already fetched.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(f"{path.suffix}.tmp")
+    # PID in the temp name: two processes writing the same session would
+    # otherwise share one temp path, interleave into the same file, and rename
+    # corrupt JSON into place — defeating the point of writing atomically. The
+    # matrix dedupe prevents that within one dispatch, but not across two, nor
+    # a local run alongside CI.
+    tmp = path.with_suffix(f"{path.suffix}.{os.getpid()}.tmp")
     tmp.write_text(json.dumps(payload, indent=1))
     tmp.replace(path)
 
@@ -409,8 +476,21 @@ def parse_args(argv=None):
     return parser.parse_args(argv)
 
 
+def _exit_on_sigterm(_signum, _frame):
+    """Turn SIGTERM into SystemExit so the summary still gets written.
+
+    Python's default SIGTERM disposition terminates the process outright — it
+    does not raise, so `except BaseException` never runs and a job killed at
+    its timeout left a partial actions table with no summary at all, which is
+    indistinguishable from a small complete session. 143 is the conventional
+    128+SIGTERM exit code.
+    """
+    sys.exit(143)
+
+
 def main(argv=None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
+    signal.signal(signal.SIGTERM, _exit_on_sigterm)
     args = parse_args(argv)
 
     ld_numbers = session_ld_numbers(args.parquet_source, args.session)

--- a/scripts/backfill_bill_status.py
+++ b/scripts/backfill_bill_status.py
@@ -326,7 +326,10 @@ def backfill(
     # summary has to say which it is. Without `complete` and `not_attempted`,
     # a run that aborted at LD 40 of 2,000 produces a file that looks like a
     # small session.
-    not_attempted = max(0, len(todo) - attempted)
+    # Measured against the FULL LD set, not against `todo`. Deriving it from
+    # `todo` made a --limit smoke test report complete: the run finishes
+    # everything it was asked for while thousands of bills remain unfetched.
+    outstanding = [ld for ld in ld_numbers if ld not in records and ld not in missing]
     summary = {
         "session": session,
         "lds_total": len(ld_numbers),
@@ -334,15 +337,15 @@ def backfill(
         "no_status_page": len(missing),
         "failed": len(failed),
         "failed_lds": failed,
-        "not_attempted": not_attempted,
+        "not_attempted": len(outstanding),
         "aborted": aborted,
-        "complete": not aborted and not_attempted == 0 and not failed,
+        "complete": not aborted and not outstanding,
         "actions_total": sum(r["action_count"] for r in records.values()),
     }
     logger.info(
         f"Session {session}: {summary['records']} records, "
         f"{summary['actions_total']} actions, {summary['no_status_page']} without a page, "
-        f"{summary['failed']} failed, {not_attempted} not attempted"
+        f"{summary['failed']} failed, {len(outstanding)} not attempted"
         f"{' (ABORTED)' if aborted else ''}"
     )
     return summary

--- a/scripts/backfill_bill_status.py
+++ b/scripts/backfill_bill_status.py
@@ -62,12 +62,21 @@ MAX_ATTEMPTS = 3
 # would be exactly that.
 MAX_CONSECUTIVE_FAILURES = 10
 
-# A long enough run of "no such bill" is not a sparse session, it is a systemic
-# problem. Enumeration comes from the parquet, so every LD we ask about is one
-# we already hold a document for -- a missing status page is anomalous BY
-# CONSTRUCTION. A wrong session number is the concrete case: the site answers
-# the identical not-found body for every LD, which without this guard produces
-# 2,000 requests, an empty actions table, and a green check.
+# A long run of "no such bill" WITH NOTHING RECORDED YET is a systemic problem,
+# not a sparse session. The concrete case is a wrong session number: the site
+# answers the identical not-found body for every LD, which without this guard
+# produced 2,000 requests, an empty actions table, and a green check.
+#
+# The `and not records` half matters. An earlier version aborted on the run
+# length alone, justified by "enumeration comes from the parquet, so every LD
+# we ask about is one we hold a document for". That reasoning is wrong: the
+# documents come from lldc.mainelegislature.org and the status pages from
+# legislature.maine.gov, which are independent systems. Review found session
+# 124 has a real page at LD 1800 and none at LD 1850 -- so a contiguous gap
+# where the document repository outruns the status application is a normal
+# thing that would have aborted a perfectly healthy session. Requiring zero
+# records keeps the wrong-session protection intact (that case never records
+# anything) while making a mid-session gap harmless.
 MAX_CONSECUTIVE_MISSING = 50
 
 # A Retry-After longer than this ends the session rather than being slept
@@ -346,13 +355,12 @@ def backfill(
             # abort. It gets its own, looser breaker instead.
             consecutive_failures = 0
             consecutive_missing += 1
-            if consecutive_missing >= MAX_CONSECUTIVE_MISSING:
+            if consecutive_missing >= MAX_CONSECUTIVE_MISSING and not records:
                 logger.error(
-                    f"Session {session}: {consecutive_missing} consecutive bills with no "
-                    f"status page; stopping after {i}/{len(todo)}. Every LD here comes "
-                    f"from the published parquet, so this many in a row means the "
-                    f"session number is wrong or the site has changed, not that the "
-                    f"bills are absent."
+                    f"Session {session}: {consecutive_missing} bills with no status page "
+                    f"and not one real page yet; stopping after {i}/{len(todo)}. That "
+                    f"pattern means the session number is wrong or the site has changed, "
+                    f"not that these particular bills are absent."
                 )
                 aborted = True
                 abort_reason = f"{consecutive_missing} consecutive bills with no status page"
@@ -493,11 +501,17 @@ def main(argv=None) -> int:
     signal.signal(signal.SIGTERM, _exit_on_sigterm)
     args = parse_args(argv)
 
-    ld_numbers = session_ld_numbers(args.parquet_source, args.session)
     out_path = args.output / f"actions-{args.session}.json"
     summary_path = args.output / f"summary-{args.session}.json"
 
+    # Inside the try as well: enumeration reads the published parquet over the
+    # network, and a session missing from it raised before any summary existed
+    # -- the one hole in "a run always leaves a summary saying what happened".
+    # Bound first so the handler can report it even when enumeration is what
+    # failed.
+    ld_numbers: list[str] = []
     try:
+        ld_numbers = session_ld_numbers(args.parquet_source, args.session)
         summary = backfill(
             args.session,
             ld_numbers,

--- a/scripts/demo_extraction.py
+++ b/scripts/demo_extraction.py
@@ -4,7 +4,9 @@
 import json
 import tempfile
 from pathlib import Path
+
 import requests
+
 from src.maine_bills.text_extractor import TextExtractor
 
 
@@ -28,31 +30,29 @@ def demo_bill_extraction(session: str, bill_id: str) -> None:
             pdf_path = Path(tmp.name)
 
         # Extract
-        print(f"\nExtracting with PyMuPDF...")
+        print("\nExtracting with PyMuPDF...")
         bill_doc = TextExtractor.extract_bill_document(pdf_path)
 
         # Display results
-        print(f"\n--- METADATA ---")
+        print("\n--- METADATA ---")
         print(f"Bill ID (from filename): {bill_id}")
         print(f"Bill ID (extracted from PDF): {bill_doc.bill_id or '(not found)'}")
         print(f"Session: {bill_doc.session or '(not found)'}")
         print(f"Title: {bill_doc.title or '(not found)'}")
         print(f"Sponsors: {', '.join(bill_doc.sponsors) if bill_doc.sponsors else '(not found)'}")
         print(f"Committee: {bill_doc.committee or '(not found)'}")
-        print(
-            f"Amended Code References: {', '.join(bill_doc.amended_code_refs) if bill_doc.amended_code_refs else '(none)'}"
-        )
+        print(f"Amended Code References: {', '.join(bill_doc.amended_code_refs) or '(none)'}")
         print(f"Extraction Confidence: {bill_doc.extraction_confidence:.2f}")
 
-        print(f"\n--- BODY TEXT (first 500 chars) ---")
+        print("\n--- BODY TEXT (first 500 chars) ---")
         print(bill_doc.body_text[:500] + "...")
 
-        print(f"\n--- TEXT STATISTICS ---")
+        print("\n--- TEXT STATISTICS ---")
         print(f"Total length: {len(bill_doc.body_text)} characters")
         print(f"Lines: {len(bill_doc.body_text.splitlines())}")
 
         # Show JSON serialization
-        print(f"\n--- JSON SERIALIZATION (metadata only) ---")
+        print("\n--- JSON SERIALIZATION (metadata only) ---")
         metadata_dict = {
             "bill_id": bill_doc.bill_id,
             "title": bill_doc.title,

--- a/scripts/demo_text_quality.py
+++ b/scripts/demo_text_quality.py
@@ -3,7 +3,9 @@
 
 import tempfile
 from pathlib import Path
+
 import requests
+
 from src.maine_bills.text_extractor import TextExtractor
 
 
@@ -26,12 +28,12 @@ def show_text_quality(session: str, bill_id: str) -> None:
         # Extract
         bill_doc = TextExtractor.extract_bill_document(pdf_path)
 
-        print(f"\n--- CLEANED BODY TEXT (lines 100-130) ---")
+        print("\n--- CLEANED BODY TEXT (lines 100-130) ---")
         lines = bill_doc.body_text.splitlines()
         for i, line in enumerate(lines[100:130], start=100):
             print(f"{i:3}: {line}")
 
-        print(f"\n--- FULL TEXT SAMPLE (showing the cleaning effect) ---")
+        print("\n--- FULL TEXT SAMPLE (showing the cleaning effect) ---")
         sample = bill_doc.body_text[1000:2000]
         print(sample)
 

--- a/scripts/run_matching_report.py
+++ b/scripts/run_matching_report.py
@@ -37,6 +37,7 @@ import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+from maine_bills.enrichment import as_aligned_list
 from maine_bills.openstates import get_roster  # noqa: E402
 from maine_bills.sponsor_matching import (  # noqa: E402
     DEFAULT_FUZZY_THRESHOLD,
@@ -47,7 +48,6 @@ from maine_bills.sponsor_matching import (  # noqa: E402
     METHOD_UNMATCHED,
     SponsorMatcher,
 )
-from maine_bills.enrichment import as_aligned_list
 from maine_bills.text_extractor import TextExtractor
 
 logger = logging.getLogger("run_matching_report")

--- a/tests/unit/test_backfill_bill_status.py
+++ b/tests/unit/test_backfill_bill_status.py
@@ -192,7 +192,9 @@ def test_server_errors_are_retried_then_reported_as_failed(backfill_mod, fake_ht
     http = fake_http(FakeSession(default=FakeResponse(503, "busy")))
     summary = backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=0)
     assert summary["failed"] == 1
-    assert len(http.requested) == backfill_mod.MAX_ATTEMPTS
+    # MAX_ATTEMPTS in the main loop, then the end-of-run retry pass tries the
+    # same bill once more with its own attempts.
+    assert len(http.requested) == backfill_mod.MAX_ATTEMPTS * 2
 
 
 def test_a_transient_error_recovers_on_retry(backfill_mod, fake_http, tmp_path):
@@ -207,7 +209,10 @@ def test_a_200_that_is_not_a_status_page_is_not_recorded(backfill_mod, fake_http
     page — it already has the identifiers. Without a shape check the run would
     record an all-null row and call it a success."""
     good = FakeResponse(200, status_page())
-    fake_http(FakeSession(sequence=[FakeResponse(200, "<html><title>Error</title></html>"), good]))
+    bad = FakeResponse(200, "<html><title>Error</title></html>")
+    # `default` set so the retry pass sees the same unrecognized page rather
+    # than falling off the end of the sequence.
+    fake_http(FakeSession(sequence=[bad, good], default=bad))
     summary = backfill_mod.backfill(132, ["0001", "0002"], tmp_path / "a.json", delay=0)
     assert summary["failed"] == 1
     assert summary["records"] == 1
@@ -313,7 +318,9 @@ def test_scattered_failures_do_not_abort_a_healthy_run(backfill_mod, fake_http, 
     """
     good, bad = FakeResponse(200, status_page()), FakeResponse(403, "")
     sequence = [bad if i % 10 == 0 else good for i in range(300)]
-    fake_http(FakeSession(sequence=sequence))
+    # `default` keeps the retry pass failing too, so the assertions below are
+    # about the breaker rather than about the fake running out of responses.
+    fake_http(FakeSession(sequence=sequence, default=bad))
     summary = backfill_mod.backfill(
         132, [f"{i:04d}" for i in range(1, 301)], tmp_path / "a.json", 0
     )
@@ -348,8 +355,9 @@ def test_no_backoff_sleep_after_the_final_attempt(backfill_mod, fake_http, sleep
     backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=1.0)
     # Backoff before attempts 2 and 3, none after 3, then the inter-bill delay.
     # Asserted as an exact sequence: filtering by value silently dropped the
-    # first backoff, which happens to equal the inter-bill delay.
-    assert sleeps == [2.0, 4.0, 1.0]
+    # first backoff, which happens to equal the inter-bill delay. The retry
+    # pass repeats the same shape, so only the first pass is pinned here.
+    assert sleeps[:3] == [2.0, 4.0, 1.0]
 
 
 def test_no_backoff_sleep_after_the_final_attempt_on_a_network_error(
@@ -364,7 +372,7 @@ def test_no_backoff_sleep_after_the_final_attempt_on_a_network_error(
 
     fake_http(ExplodingSession())
     backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=1.0)
-    assert sleeps == [1.0, 2.0, 1.0]
+    assert sleeps[:3] == [1.0, 2.0, 1.0]
 
 
 def test_a_missing_bill_resets_the_failure_streak(backfill_mod, fake_http, tmp_path):
@@ -867,3 +875,74 @@ def test_limit_caps_the_run_for_a_smoke_test(backfill_mod, fake_http, tmp_path):
     http = fake_http(FakeSession(default=FakeResponse(200, status_page())))
     backfill_mod.backfill(132, ["0001", "0002", "0003"], tmp_path / "a.json", delay=0, limit=2)
     assert len(http.requested) == 2
+
+
+# --- the end-of-run retry pass, added after the smoke run ---
+
+
+def test_a_transient_tail_of_failures_is_retried_and_the_session_completes(
+    backfill_mod, fake_http, tmp_path
+):
+    """The case the smoke run actually hit.
+
+    Sessions 132 and 121 each finished 2034/2041 and 1957/1965, failing only on
+    a handful of read timeouts, and each reported incomplete and exited 1 over
+    them. A CI job cannot resume, so recovering seven bills would have meant
+    refetching two thousand pages — worse for us and ruder to the site than
+    seven requests at the end of the run.
+    """
+    good, flaky = FakeResponse(200, status_page()), FakeResponse(503, "")
+    # Bill 3 fails its three attempts, then succeeds on the retry pass.
+    sequence = [good, good, flaky, flaky, flaky, good, good]
+    fake_http(FakeSession(sequence=sequence, default=good))
+    summary = backfill_mod.backfill(
+        132, ["0001", "0002", "0003", "0004"], tmp_path / "a.json", delay=0
+    )
+
+    assert summary["failed"] == 0
+    assert summary["records"] == 4
+    assert summary["complete"] is True
+
+
+def test_the_retry_pass_does_not_re_drive_a_session_that_failed_in_bulk(
+    backfill_mod, fake_http, tmp_path
+):
+    """Bounded on purpose: a session failing at scale has something actually
+    wrong with it, and re-driving all of it is what the breakers exist to
+    prevent. Only a transient-looking tail is retried."""
+    lds = [f"{i:04d}" for i in range(1, 401)]
+    # Alternate so the consecutive-failure breaker never fires but the failure
+    # count climbs past the retry ceiling.
+    good, bad = FakeResponse(200, status_page()), FakeResponse(403, "")
+    fake_http(FakeSession(sequence=[bad if i % 2 else good for i in range(400)], default=good))
+    summary = backfill_mod.backfill(132, lds, tmp_path / "a.json", delay=0)
+
+    assert summary["failed"] > backfill_mod.MAX_RETRY_PASS
+    assert summary["complete"] is False
+
+
+def test_an_aborted_run_is_not_retried(backfill_mod, fake_http, tmp_path):
+    """If the breaker stopped us, going back for more is exactly wrong."""
+    http = fake_http(FakeSession(default=FakeResponse(403, "blocked")))
+    lds = [f"{i:04d}" for i in range(1, 101)]
+    summary = backfill_mod.backfill(132, lds, tmp_path / "a.json", delay=0)
+    assert summary["aborted"] is True
+    assert len(http.requested) == backfill_mod.MAX_CONSECUTIVE_FAILURES
+
+
+def test_the_retry_pass_records_a_bill_that_turns_out_to_be_missing(
+    backfill_mod, fake_http, tmp_path
+):
+    """A retried bill answering "no such bill" belongs in the sidecar, not the
+    failed list — otherwise it is refetched forever."""
+    good, flaky = FakeResponse(200, status_page()), FakeResponse(503, "")
+    fake_http(
+        FakeSession(
+            sequence=[good, flaky, flaky, flaky],
+            default=FakeResponse(200, not_found_page()),
+        )
+    )
+    summary = backfill_mod.backfill(132, ["0001", "0002"], tmp_path / "a.json", delay=0)
+    assert summary["failed"] == 0
+    assert summary["no_status_page"] == 1
+    assert json.loads((tmp_path / "a-missing.json").read_text()) == ["0002"]

--- a/tests/unit/test_backfill_bill_status.py
+++ b/tests/unit/test_backfill_bill_status.py
@@ -1,0 +1,213 @@
+"""Tests for the bill status backfill (sprint node N3).
+
+All offline: the network is a fake session, and `time.sleep` is patched out so
+the rate limit doesn't make the suite slow.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "backfill_bill_status.py"
+
+
+@pytest.fixture(scope="module")
+def backfill_mod():
+    spec = importlib.util.spec_from_file_location("backfill_bill_status", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch, backfill_mod):
+    monkeypatch.setattr(backfill_mod.time, "sleep", lambda _s: None)
+
+
+def status_page(session=132, ld="1", paper="SP 29", rows=(("Jan 15, 2025", "Voted", "OTP"),)):
+    docket = "".join(f"<tr><td>{d}</td><td>{a}</td><td>{r}</td></tr>" for d, a, r in rows)
+    return f"""
+    <html><head><title>LD {ld}, {paper}, Text and Status, {session}nd Legislature,
+    First Regular Session</title></head><body>
+      <h1>{session}nd Maine Legislature</h1><h2>An Act To Do A Thing</h2>
+      <div id="flags"></div>
+      <div id="sec0">Documents and Disposition</div>
+      <div id="sec3">Status In Committee
+        <table><tr><td></td></tr>
+        <tr><td>Date</td><td>Action</td><td>Result</td></tr>{docket}</table></div>
+    </body></html>
+    """
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+class FakeSession:
+    """Serves canned responses by URL; records every request made."""
+
+    def __init__(self, by_url=None, default=None, sequence=None):
+        self.by_url = by_url or {}
+        self.default = default
+        self.sequence = list(sequence or [])
+        self.requested: list[str] = []
+        self.headers: dict = {}
+
+    def get(self, url, timeout=None):
+        self.requested.append(url)
+        if self.sequence:
+            return self.sequence.pop(0)
+        if url in self.by_url:
+            return self.by_url[url]
+        return self.default or FakeResponse(404, "not found")
+
+
+@pytest.fixture
+def fake_http(backfill_mod, monkeypatch):
+    def install(session_obj):
+        monkeypatch.setattr(backfill_mod, "http_session", lambda: session_obj)
+        return session_obj
+
+    return install
+
+
+# --- politeness, which is the part with an outside party ---
+
+
+def test_requests_go_to_the_robots_allowed_path(backfill_mod, fake_http, tmp_path):
+    http = fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    backfill_mod.backfill(132, ["0001", "0002"], tmp_path / "a.json", delay=0)
+    assert all("display_ps.asp" in u for u in http.requested)
+    assert not any("default_ps" in u or "LawMakerWeb" in u for u in http.requested)
+
+
+def test_one_request_per_bill(backfill_mod, fake_http, tmp_path):
+    http = fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    backfill_mod.backfill(132, ["0001", "0002", "0003"], tmp_path / "a.json", delay=0)
+    assert len(http.requested) == 3
+
+
+def test_urls_are_unpadded_even_though_records_are_padded(backfill_mod, fake_http, tmp_path):
+    """The site wants LD=1; the record must key as "0001"."""
+    http = fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=0)
+    assert http.requested == [
+        "https://legislature.maine.gov/legis/bills/display_ps.asp?LD=1&snum=132"
+    ]
+    assert json.loads((tmp_path / "a.json").read_text())[0]["ld_number"] == "0001"
+
+
+# --- failure handling: one bad bill must not cost the session ---
+
+
+def test_404_is_recorded_as_no_status_page_and_not_retried(backfill_mod, fake_http, tmp_path):
+    http = fake_http(FakeSession(default=FakeResponse(404, "nope")))
+    summary = backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=0)
+    assert summary["no_status_page"] == 1
+    assert summary["failed"] == 0
+    assert len(http.requested) == 1, "a 404 will still be a 404; retrying wastes a request"
+
+
+def test_server_errors_are_retried_then_reported_as_failed(backfill_mod, fake_http, tmp_path):
+    http = fake_http(FakeSession(default=FakeResponse(503, "busy")))
+    summary = backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=0)
+    assert summary["failed"] == 1
+    assert len(http.requested) == backfill_mod.MAX_ATTEMPTS
+
+
+def test_a_transient_error_recovers_on_retry(backfill_mod, fake_http, tmp_path):
+    fake_http(FakeSession(sequence=[FakeResponse(503, ""), FakeResponse(200, status_page())]))
+    summary = backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=0)
+    assert summary["records"] == 1
+    assert summary["failed"] == 0
+
+
+def test_a_200_that_is_not_a_status_page_is_not_recorded(backfill_mod, fake_http, tmp_path):
+    """The session/ld overrides mean parse_status_page cannot raise on an error
+    page — it already has the identifiers. Without a shape check the run would
+    record an all-null row and call it a success."""
+    good = FakeResponse(200, status_page())
+    fake_http(FakeSession(sequence=[FakeResponse(200, "<html><title>Error</title></html>"), good]))
+    summary = backfill_mod.backfill(132, ["0001", "0002"], tmp_path / "a.json", delay=0)
+    assert summary["failed"] == 1
+    assert summary["records"] == 1
+    assert [r["ld_number"] for r in json.loads((tmp_path / "a.json").read_text())] == ["0002"]
+
+
+def test_a_bill_with_no_docket_is_still_a_valid_record(backfill_mod, fake_http, tmp_path):
+    """Empty docket is legitimate — it must not be mistaken for an error page."""
+    fake_http(FakeSession(default=FakeResponse(200, status_page(rows=()))))
+    summary = backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=0)
+    assert summary["records"] == 1
+    assert summary["failed"] == 0
+    assert json.loads((tmp_path / "a.json").read_text())[0]["action_count"] == 0
+
+
+# --- resumability, which is what makes a 40-minute job restartable ---
+
+
+def test_an_existing_output_is_resumed_not_refetched(backfill_mod, fake_http, tmp_path):
+    out = tmp_path / "a.json"
+    http = fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    backfill_mod.backfill(132, ["0001", "0002"], out, delay=0)
+    assert len(http.requested) == 2
+
+    http2 = fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    summary = backfill_mod.backfill(132, ["0001", "0002", "0003"], out, delay=0)
+    assert http2.requested == [
+        "https://legislature.maine.gov/legis/bills/display_ps.asp?LD=3&snum=132"
+    ]
+    assert summary["records"] == 3
+
+
+def test_a_corrupt_output_file_restarts_rather_than_crashing(backfill_mod, fake_http, tmp_path):
+    out = tmp_path / "a.json"
+    out.write_text("{ this is not json")
+    fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    assert backfill_mod.backfill(132, ["0001"], out, delay=0)["records"] == 1
+
+
+def test_progress_is_checkpointed_mid_run(backfill_mod, fake_http, tmp_path):
+    """A crash at bill 900 of 2500 must not discard the first 899."""
+    out = tmp_path / "a.json"
+    fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    backfill_mod.backfill(132, [f"{i:04d}" for i in range(1, 7)], out, delay=0, checkpoint_every=2)
+    assert len(json.loads(out.read_text())) == 6
+
+
+# --- the record shape the actions config will be built from ---
+
+
+def test_record_carries_the_docket_and_the_join_key(backfill_mod, fake_http, tmp_path):
+    rows = (("Jan 15, 2025", "Work Session Held", ""), ("Jan 21, 2025", "Reported Out", "OTP-AM"))
+    fake_http(FakeSession(default=FakeResponse(200, status_page(rows=rows))))
+    backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=0)
+
+    record = json.loads((tmp_path / "a.json").read_text())[0]
+    assert (record["session"], record["ld_number"]) == (132, "0001")
+    assert record["action_count"] == 2
+    assert record["actions"][1] == {
+        "date": "2025-01-21",
+        "action": "Reported Out",
+        "result": "OTP-AM",
+        "raw_date": "Jan 21, 2025",
+    }
+
+
+def test_summary_totals_actions_across_bills(backfill_mod, fake_http, tmp_path):
+    rows = (("Jan 15, 2025", "Voted", "OTP"), ("Jan 21, 2025", "Reported Out", "OTP"))
+    fake_http(FakeSession(default=FakeResponse(200, status_page(rows=rows))))
+    summary = backfill_mod.backfill(132, ["0001", "0002"], tmp_path / "a.json", delay=0)
+    assert summary["actions_total"] == 4
+
+
+def test_limit_caps_the_run_for_a_smoke_test(backfill_mod, fake_http, tmp_path):
+    http = fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    backfill_mod.backfill(132, ["0001", "0002", "0003"], tmp_path / "a.json", delay=0, limit=2)
+    assert len(http.requested) == 2

--- a/tests/unit/test_backfill_bill_status.py
+++ b/tests/unit/test_backfill_bill_status.py
@@ -24,8 +24,17 @@ def backfill_mod():
 
 
 @pytest.fixture(autouse=True)
-def no_sleep(monkeypatch, backfill_mod):
-    monkeypatch.setattr(backfill_mod.time, "sleep", lambda _s: None)
+def sleeps(monkeypatch, backfill_mod):
+    """Record sleeps instead of taking them.
+
+    A `lambda _s: None` that recorded nothing left the rate limit untested:
+    deleting `time.sleep(delay)` from the request loop entirely kept the whole
+    suite green. Politeness is the one behaviour here with an outside party, so
+    it gets asserted.
+    """
+    taken: list[float] = []
+    monkeypatch.setattr(backfill_mod.time, "sleep", taken.append)
+    return taken
 
 
 def status_page(session=132, ld="1", paper="SP 29", rows=(("Jan 15, 2025", "Voted", "OTP"),)):
@@ -85,6 +94,46 @@ def test_requests_go_to_the_robots_allowed_path(backfill_mod, fake_http, tmp_pat
     backfill_mod.backfill(132, ["0001", "0002"], tmp_path / "a.json", delay=0)
     assert all("display_ps.asp" in u for u in http.requested)
     assert not any("default_ps" in u or "LawMakerWeb" in u for u in http.requested)
+
+
+def test_every_request_is_followed_by_the_configured_delay(
+    backfill_mod, fake_http, sleeps, tmp_path
+):
+    """The 1 req/sec is the design, per the module docstring and the workflow
+    comment. Deleting it must not be invisible."""
+    fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    backfill_mod.backfill(132, ["0001", "0002", "0003"], tmp_path / "a.json", delay=1.0)
+    assert sleeps == [1.0, 1.0, 1.0]
+
+
+def test_the_delay_is_honored_at_other_rates(backfill_mod, fake_http, sleeps, tmp_path):
+    fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    backfill_mod.backfill(132, ["0001", "0002"], tmp_path / "a.json", delay=2.5)
+    assert sleeps == [2.5, 2.5]
+
+
+def test_requests_carry_a_contactable_user_agent(backfill_mod):
+    """A state server should be able to tell who is asking and why."""
+    backfill_mod._HTTP = None
+    try:
+        agent = backfill_mod.http_session().headers["User-Agent"]
+    finally:
+        backfill_mod._HTTP = None
+    assert "github.com/PhilipMathieu/maine-bills" in agent
+
+
+def test_requests_use_a_timeout(backfill_mod, fake_http, tmp_path):
+    """Without one a hung connection stalls the whole session indefinitely."""
+    seen = {}
+
+    class RecordingSession(FakeSession):
+        def get(self, url, timeout=None):
+            seen["timeout"] = timeout
+            return super().get(url, timeout=timeout)
+
+    fake_http(RecordingSession(default=FakeResponse(200, status_page())))
+    backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=0)
+    assert seen["timeout"] == backfill_mod.REQUEST_TIMEOUT
 
 
 def test_one_request_per_bill(backfill_mod, fake_http, tmp_path):
@@ -149,6 +198,127 @@ def test_a_bill_with_no_docket_is_still_a_valid_record(backfill_mod, fake_http, 
     assert json.loads((tmp_path / "a.json").read_text())[0]["action_count"] == 0
 
 
+# --- the site soft-404s, which is the whole shape of "no such bill" here ---
+
+
+def not_found_page():
+    """The real not-found page: 200, normal chrome, no paper number.
+
+    Captured from display_ps.asp?LD=9999&snum=132. The heading is what
+    _parse_bill_title's longest-heading fallback picks up.
+    """
+    return (
+        "<html><head><title>Maine Legislature</title></head><body>"
+        "<h1>Cannot find requested paper,<br> please provide a Paper or LD "
+        "number in the box to the left.</h1>"
+        "<p>Please call Legislative Information at 287-1692 for assistance.</p>"
+        "</body></html>"
+    )
+
+
+def test_the_soft_404_is_not_recorded_as_a_bill(backfill_mod, fake_http, tmp_path):
+    """The site answers 200 for a nonexistent LD. Accepting `paper or title`
+    let the error heading through as an act title, so every nonexistent LD in
+    every session would have been stored as a real bill titled "Cannot find
+    requested paper..." and the run would have reported success."""
+    fake_http(FakeSession(default=FakeResponse(200, not_found_page())))
+    summary = backfill_mod.backfill(132, ["9999"], tmp_path / "a.json", delay=0)
+    assert summary["records"] == 0
+    assert summary["no_status_page"] == 1
+    assert summary["failed"] == 0, "a plain answer from the site is not a failure"
+    assert json.loads((tmp_path / "a.json").read_text()) == []
+
+
+def test_the_soft_404_is_persisted_like_a_hard_404(backfill_mod, fake_http, tmp_path):
+    """Since this host never hard-404s, persistence has to key off the soft one
+    or the resume optimization does nothing at all in practice."""
+    out = tmp_path / "a.json"
+    fake_http(FakeSession(default=FakeResponse(200, not_found_page())))
+    backfill_mod.backfill(132, ["9999"], out, delay=0)
+    assert json.loads((tmp_path / "a-missing.json").read_text()) == ["9999"]
+
+    http2 = fake_http(FakeSession(default=FakeResponse(200, not_found_page())))
+    backfill_mod.backfill(132, ["9999"], out, delay=0)
+    assert http2.requested == []
+
+
+def test_an_unrecognized_200_is_a_failure_not_a_missing_bill(backfill_mod, fake_http, tmp_path):
+    """A WAF challenge or outage page is transient. Recording it as "this bill
+    does not exist" would persist it and never ask again."""
+    fake_http(FakeSession(default=FakeResponse(200, "<html><body>Access denied</body></html>")))
+    summary = backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=0)
+    assert summary["failed"] == 1
+    assert summary["no_status_page"] == 0
+    assert (
+        not (tmp_path / "a-missing.json").exists()
+        or json.loads((tmp_path / "a-missing.json").read_text()) == []
+    )
+
+
+# --- the circuit breaker: not being a burden when the site says stop ---
+
+
+def test_sustained_failure_aborts_instead_of_running_the_whole_session(
+    backfill_mod, fake_http, tmp_path
+):
+    """Per-LD retry alone means a blocked run still issues one request per
+    remaining bill. Against a state server that has already refused, times
+    three concurrent sessions, that is the exact harm the throttle exists to
+    avoid."""
+    http = fake_http(FakeSession(default=FakeResponse(403, "blocked")))
+    lds = [f"{i:04d}" for i in range(1, 501)]
+    summary = backfill_mod.backfill(132, lds, tmp_path / "a.json", delay=0)
+
+    assert summary["aborted"] is True
+    assert len(http.requested) == backfill_mod.MAX_CONSECUTIVE_FAILURES
+    assert summary["not_attempted"] == 500 - backfill_mod.MAX_CONSECUTIVE_FAILURES
+    assert summary["complete"] is False
+
+
+def test_scattered_failures_do_not_abort_a_healthy_run(backfill_mod, fake_http, tmp_path):
+    """The breaker is for a site that has stopped answering, not for one bad
+    bill every so often."""
+    good, bad = FakeResponse(200, status_page()), FakeResponse(500, "")
+    sequence = []
+    for i in range(30):
+        sequence.append(bad if i % 5 == 0 else good)
+    # A 500 is retried MAX_ATTEMPTS times, so pad the sequence generously.
+    fake_http(FakeSession(sequence=sequence + [good] * 200))
+    summary = backfill_mod.backfill(132, [f"{i:04d}" for i in range(1, 31)], tmp_path / "a.json", 0)
+    assert summary["aborted"] is False
+
+
+def test_missing_bills_do_not_trip_the_breaker(backfill_mod, fake_http, tmp_path):
+    """A session with a long run of nonexistent LDs is normal, not a refusal."""
+    fake_http(FakeSession(default=FakeResponse(200, not_found_page())))
+    lds = [f"{i:04d}" for i in range(1, 41)]
+    summary = backfill_mod.backfill(132, lds, tmp_path / "a.json", delay=0)
+    assert summary["aborted"] is False
+    assert summary["no_status_page"] == 40
+
+
+def test_retry_after_is_honored_over_our_own_backoff(backfill_mod, fake_http, sleeps, tmp_path):
+    busy = FakeResponse(503, "")
+    busy.headers = {"Retry-After": "7"}
+    fake_http(FakeSession(sequence=[busy, FakeResponse(200, status_page())]))
+    backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=1.0)
+    assert 7.0 in sleeps, "the server told us how long to wait"
+
+
+def test_an_absurd_retry_after_is_capped(backfill_mod):
+    class R:
+        headers = {"Retry-After": "999999"}
+
+    assert backfill_mod.retry_after(R(), 2.0) == 300.0
+
+
+def test_a_junk_retry_after_falls_back_to_our_backoff(backfill_mod):
+    class R:
+        headers = {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+
+    assert backfill_mod.retry_after(R(), 2.0) == 2.0
+
+
 # --- resumability, which is what makes a 40-minute job restartable ---
 
 
@@ -209,6 +379,41 @@ def test_recheck_missing_reopens_the_known_404s(backfill_mod, fake_http, tmp_pat
     assert summary["no_status_page"] == 0
 
 
+def test_an_incomplete_recheck_does_not_forget_the_rest_of_the_missing_set(
+    backfill_mod, fake_http, tmp_path
+):
+    """Regression: --recheck-missing started from an empty set and overwrote the
+    sidecar with only what it re-reached, so a recheck cut short by --limit, a
+    crash, or the job timeout erased every LD it had not got to yet. The next
+    normal run then re-asked the site for all of them."""
+    out = tmp_path / "a.json"
+    lds = [f"{i:04d}" for i in range(1, 6)]
+    fake_http(FakeSession(default=FakeResponse(200, not_found_page())))
+    backfill_mod.backfill(132, lds, out, delay=0)
+    assert len(json.loads((tmp_path / "a-missing.json").read_text())) == 5
+
+    fake_http(FakeSession(default=FakeResponse(200, not_found_page())))
+    backfill_mod.backfill(132, lds, out, delay=0, recheck_missing=True, limit=1)
+    assert json.loads((tmp_path / "a-missing.json").read_text()) == lds, (
+        "the four LDs this run never reached must still be recorded as missing"
+    )
+
+    http = fake_http(FakeSession(default=FakeResponse(200, not_found_page())))
+    backfill_mod.backfill(132, lds, out, delay=0)
+    assert http.requested == [], "a normal resume must not refetch them"
+
+
+def test_a_recheck_that_finds_a_page_removes_only_that_ld(backfill_mod, fake_http, tmp_path):
+    out = tmp_path / "a.json"
+    lds = ["0001", "0002", "0003"]
+    fake_http(FakeSession(default=FakeResponse(200, not_found_page())))
+    backfill_mod.backfill(132, lds, out, delay=0)
+
+    fake_http(FakeSession(sequence=[FakeResponse(200, status_page())]))
+    backfill_mod.backfill(132, lds, out, delay=0, recheck_missing=True, limit=1)
+    assert json.loads((tmp_path / "a-missing.json").read_text()) == ["0002", "0003"]
+
+
 def test_the_missing_sidecar_does_not_pollute_the_actions_table(backfill_mod, fake_http, tmp_path):
     out = tmp_path / "a.json"
     fake_http(FakeSession(sequence=[FakeResponse(404, ""), FakeResponse(200, status_page())]))
@@ -236,11 +441,61 @@ def test_a_corrupt_output_file_restarts_rather_than_crashing(backfill_mod, fake_
 
 
 def test_progress_is_checkpointed_mid_run(backfill_mod, fake_http, tmp_path):
-    """A crash at bill 900 of 2500 must not discard the first 899."""
+    """A crash at bill 900 of 2500 must not discard the first 899.
+
+    Asserted DURING the run: checking the file afterwards passes even with
+    checkpointing deleted entirely, because the final write produces the same
+    result. The whole point is what is on disk before the run ends.
+    """
+    out = tmp_path / "a.json"
+    on_disk = []
+
+    class WatchingSession(FakeSession):
+        def get(self, url, timeout=None):
+            on_disk.append(len(json.loads(out.read_text())) if out.exists() else 0)
+            return super().get(url, timeout=timeout)
+
+    fake_http(WatchingSession(default=FakeResponse(200, status_page())))
+    backfill_mod.backfill(132, [f"{i:04d}" for i in range(1, 7)], out, delay=0, checkpoint_every=2)
+
+    assert len(json.loads(out.read_text())) == 6
+    # Before requests 3 and 5 the first 2 and 4 records must already be saved.
+    assert on_disk == [0, 0, 2, 2, 4, 4]
+
+
+def test_a_truncated_checkpoint_does_not_discard_the_session(backfill_mod, fake_http, tmp_path):
+    """A kill mid-write used to leave half a JSON file, which load_existing
+    treats as "start fresh" — silently re-requesting ~2000 already-fetched
+    pages. Writes go through a temp file and a rename instead."""
     out = tmp_path / "a.json"
     fake_http(FakeSession(default=FakeResponse(200, status_page())))
-    backfill_mod.backfill(132, [f"{i:04d}" for i in range(1, 7)], out, delay=0, checkpoint_every=2)
-    assert len(json.loads(out.read_text())) == 6
+    backfill_mod.backfill(132, [f"{i:04d}" for i in range(1, 5)], out, delay=0)
+
+    # Nothing should be left behind that a resume would trip over.
+    assert list(tmp_path.glob("*.tmp")) == []
+    http = fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    backfill_mod.backfill(132, [f"{i:04d}" for i in range(1, 5)], out, delay=0)
+    assert http.requested == []
+
+
+def test_a_write_that_dies_partway_leaves_the_previous_file_intact(
+    backfill_mod, monkeypatch, tmp_path
+):
+    """The property atomicity actually buys. A plain write_text truncates the
+    destination before the new bytes land, so a kill during a checkpoint costs
+    the whole session; writing to a temp file and renaming cannot.
+    """
+    out = tmp_path / "a.json"
+    backfill_mod.write_json(out, [{"ld_number": "0001"}])
+
+    def die(self, target):
+        raise OSError("killed during rename")
+
+    monkeypatch.setattr(Path, "replace", die)
+    with pytest.raises(OSError):
+        backfill_mod.write_json(out, [{"ld_number": "9999"}])
+
+    assert json.loads(out.read_text()) == [{"ld_number": "0001"}]
 
 
 # --- the record shape the actions config will be built from ---
@@ -267,6 +522,77 @@ def test_summary_totals_actions_across_bills(backfill_mod, fake_http, tmp_path):
     fake_http(FakeSession(default=FakeResponse(200, status_page(rows=rows))))
     summary = backfill_mod.backfill(132, ["0001", "0002"], tmp_path / "a.json", delay=0)
     assert summary["actions_total"] == 4
+
+
+# --- the exit code, which is how a dispatched run reports itself ---
+
+
+def run_main(backfill_mod, monkeypatch, fake_http, tmp_path, response, lds=("0001",)):
+    monkeypatch.setattr(backfill_mod, "session_ld_numbers", lambda _src, _s: list(lds))
+    fake_http(FakeSession(default=response))
+    code = backfill_mod.main(
+        [
+            "--session",
+            "132",
+            "--parquet-source",
+            "unused",
+            "--output",
+            str(tmp_path),
+            "--delay",
+            "0",
+        ]
+    )
+    return code, json.loads((tmp_path / "summary-132.json").read_text())
+
+
+def test_a_clean_run_exits_zero(backfill_mod, monkeypatch, fake_http, tmp_path):
+    code, summary = run_main(
+        backfill_mod, monkeypatch, fake_http, tmp_path, FakeResponse(200, status_page())
+    )
+    assert code == 0
+    assert summary["complete"] is True
+
+
+def test_a_session_of_nonexistent_bills_still_exits_zero(
+    backfill_mod, monkeypatch, fake_http, tmp_path
+):
+    """Missing bills are a plain answer from the site, not a failure."""
+    code, summary = run_main(
+        backfill_mod, monkeypatch, fake_http, tmp_path, FakeResponse(200, not_found_page())
+    )
+    assert code == 0
+    assert summary["complete"] is True
+
+
+def test_a_blocked_run_exits_non_zero(backfill_mod, monkeypatch, fake_http, tmp_path):
+    """Returning 0 unconditionally meant a run blocked at request one produced a
+    green check and an empty artifact — indistinguishable from success."""
+    lds = [f"{i:04d}" for i in range(1, 60)]
+    code, summary = run_main(
+        backfill_mod, monkeypatch, fake_http, tmp_path, FakeResponse(403, "blocked"), lds=lds
+    )
+    assert code == 1
+    assert summary["aborted"] is True
+    assert summary["complete"] is False
+
+
+def test_a_crash_still_leaves_a_summary_saying_it_failed(
+    backfill_mod, monkeypatch, fake_http, tmp_path
+):
+    """Otherwise the artifact holds a partial actions table and no summary,
+    which looks exactly like a small complete session."""
+    monkeypatch.setattr(backfill_mod, "session_ld_numbers", lambda _src, _s: ["0001"])
+
+    def boom(*_a, **_k):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(backfill_mod, "backfill", boom)
+    with pytest.raises(KeyboardInterrupt):
+        backfill_mod.main(["--session", "132", "--parquet-source", "u", "--output", str(tmp_path)])
+
+    summary = json.loads((tmp_path / "summary-132.json").read_text())
+    assert summary["complete"] is False
+    assert "KeyboardInterrupt" in summary["error"]
 
 
 def test_limit_caps_the_run_for_a_smoke_test(backfill_mod, fake_http, tmp_path):

--- a/tests/unit/test_backfill_bill_status.py
+++ b/tests/unit/test_backfill_bill_status.py
@@ -271,7 +271,9 @@ def test_sustained_failure_aborts_instead_of_running_the_whole_session(
 
     assert summary["aborted"] is True
     assert len(http.requested) == backfill_mod.MAX_CONSECUTIVE_FAILURES
-    assert summary["not_attempted"] == 500 - backfill_mod.MAX_CONSECUTIVE_FAILURES
+    # All 500 remain outstanding: the 10 we did try failed, so they still need
+    # fetching too. "Not attempted" counts what a rerun must still do.
+    assert summary["not_attempted"] == 500
     assert summary["complete"] is False
 
 
@@ -593,6 +595,20 @@ def test_a_crash_still_leaves_a_summary_saying_it_failed(
     summary = json.loads((tmp_path / "summary-132.json").read_text())
     assert summary["complete"] is False
     assert "KeyboardInterrupt" in summary["error"]
+
+
+def test_a_limited_smoke_test_does_not_claim_the_session_is_complete(
+    backfill_mod, fake_http, tmp_path
+):
+    """Completeness is measured against the full LD set. Derived from the run's
+    own todo list, --limit reported complete: the run finished everything it was
+    asked for while thousands of bills remained unfetched."""
+    fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    lds = [f"{i:04d}" for i in range(1, 101)]
+    summary = backfill_mod.backfill(132, lds, tmp_path / "a.json", delay=0, limit=3)
+    assert summary["records"] == 3
+    assert summary["not_attempted"] == 97
+    assert summary["complete"] is False
 
 
 def test_limit_caps_the_run_for_a_smoke_test(backfill_mod, fake_http, tmp_path):

--- a/tests/unit/test_backfill_bill_status.py
+++ b/tests/unit/test_backfill_bill_status.py
@@ -384,6 +384,65 @@ def test_a_missing_bill_resets_the_failure_streak(backfill_mod, fake_http, tmp_p
     assert summary["aborted"] is False
 
 
+def test_a_gap_in_a_working_session_does_not_abort_it(backfill_mod, fake_http, tmp_path):
+    """The missing breaker requires that NOTHING has been recorded yet.
+
+    The documents come from lldc.mainelegislature.org and the status pages from
+    legislature.maine.gov — independent systems — so a contiguous stretch where
+    the document repository outruns the status application is normal. Session
+    124 has a real page at LD 1800 and none at LD 1850. Aborting on the run
+    length alone would kill a healthy session for it.
+    """
+    good, gone = FakeResponse(200, status_page()), FakeResponse(200, not_found_page())
+    # One real bill, then a gap three times longer than the breaker's threshold.
+    sequence = [good] + [gone] * (backfill_mod.MAX_CONSECUTIVE_MISSING * 3)
+    http = fake_http(FakeSession(sequence=sequence))
+    lds = [f"{i:04d}" for i in range(1, len(sequence) + 1)]
+    summary = backfill_mod.backfill(124, lds, tmp_path / "a.json", delay=0)
+
+    assert summary["aborted"] is False
+    assert len(http.requested) == len(lds)
+    assert summary["records"] == 1
+    assert summary["complete"] is True
+
+
+def test_a_missing_bill_does_not_reset_the_failure_streak_counter(
+    backfill_mod, fake_http, tmp_path
+):
+    """The failure branch clears `consecutive_missing`. Without it, missing
+    bills scattered between failures accumulate toward the missing breaker and
+    could abort a run where they were never consecutive at all."""
+    gone, bad = FakeResponse(200, not_found_page()), FakeResponse(403, "")
+    sequence = []
+    for _ in range(30):
+        sequence.extend([gone] * 5 + [bad])
+    fake_http(FakeSession(sequence=sequence))
+    lds = [f"{i:04d}" for i in range(1, 181)]
+    summary = backfill_mod.backfill(132, lds, tmp_path / "a.json", delay=0)
+    assert summary["abort_reason"] is None or "consecutive failures" in summary["abort_reason"]
+
+
+def test_the_missing_breaker_records_why_it_stopped(backfill_mod, fake_http, tmp_path):
+    fake_http(FakeSession(default=FakeResponse(200, not_found_page())))
+    lds = [f"{i:04d}" for i in range(1, 201)]
+    summary = backfill_mod.backfill(140, lds, tmp_path / "a.json", delay=0)
+    assert summary["aborted"] is True
+    assert "no status page" in summary["abort_reason"]
+
+
+def test_a_retry_after_exactly_at_the_threshold_is_slept_not_aborted(
+    backfill_mod, fake_http, sleeps, tmp_path
+):
+    """Pins the boundary: the abort is for a wait LONGER than we will sit
+    through, so the threshold value itself is still honored normally."""
+    busy = FakeResponse(503, "")
+    busy.headers = {"Retry-After": str(int(backfill_mod.RETRY_AFTER_ABORT))}
+    fake_http(FakeSession(sequence=[busy, FakeResponse(200, status_page())]))
+    summary = backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=1.0)
+    assert summary["aborted"] is False
+    assert backfill_mod.RETRY_AFTER_ABORT in sleeps
+
+
 def test_missing_bills_do_not_trip_the_breaker(backfill_mod, fake_http, tmp_path):
     """A session with a long run of nonexistent LDs is normal, not a refusal."""
     fake_http(FakeSession(default=FakeResponse(200, not_found_page())))
@@ -765,6 +824,10 @@ def test_sigterm_still_leaves_a_summary(tmp_path):
     summary = json.loads(summary_path.read_text())
     assert summary["complete"] is False
     assert summary["aborted"] is True
+    # The signal path bypasses main()'s `return 1` entirely, so the exit code is
+    # whatever the handler names. 128+SIGTERM by convention; without this
+    # assertion the handler could exit 0 and report a killed job as a success.
+    assert proc.returncode == 143
 
 
 def test_a_crash_still_leaves_a_summary_saying_it_failed(

--- a/tests/unit/test_backfill_bill_status.py
+++ b/tests/unit/test_backfill_bill_status.py
@@ -166,6 +166,68 @@ def test_an_existing_output_is_resumed_not_refetched(backfill_mod, fake_http, tm
     assert summary["records"] == 3
 
 
+def test_a_404_is_persisted_so_a_resumed_run_does_not_ask_again(backfill_mod, fake_http, tmp_path):
+    """Without this, every resume re-asks the site for pages known not to exist —
+    wasted requests against a state server, which is the whole thing this script
+    is careful about."""
+    out = tmp_path / "a.json"
+    http = fake_http(FakeSession(default=FakeResponse(404, "nope")))
+    backfill_mod.backfill(132, ["0001", "0002"], out, delay=0)
+    assert len(http.requested) == 2
+
+    http2 = fake_http(FakeSession(default=FakeResponse(404, "nope")))
+    summary = backfill_mod.backfill(132, ["0001", "0002"], out, delay=0)
+    assert http2.requested == []
+    assert summary["no_status_page"] == 2, "the count must survive the resume too"
+
+
+def test_server_errors_are_not_persisted_and_are_retried_on_resume(
+    backfill_mod, fake_http, tmp_path
+):
+    """A 503 is transient. Retrying it is the main reason to resume at all, so it
+    must not be recorded alongside the definitive 404s."""
+    out = tmp_path / "a.json"
+    fake_http(FakeSession(default=FakeResponse(503, "busy")))
+    backfill_mod.backfill(132, ["0001"], out, delay=0)
+
+    http2 = fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    summary = backfill_mod.backfill(132, ["0001"], out, delay=0)
+    assert len(http2.requested) == 1
+    assert summary["records"] == 1
+
+
+def test_recheck_missing_reopens_the_known_404s(backfill_mod, fake_http, tmp_path):
+    """A session still in progress can gain a page after we looked."""
+    out = tmp_path / "a.json"
+    fake_http(FakeSession(default=FakeResponse(404, "nope")))
+    backfill_mod.backfill(132, ["0001"], out, delay=0)
+
+    http2 = fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    summary = backfill_mod.backfill(132, ["0001"], out, delay=0, recheck_missing=True)
+    assert len(http2.requested) == 1
+    assert summary["records"] == 1
+    assert summary["no_status_page"] == 0
+
+
+def test_the_missing_sidecar_does_not_pollute_the_actions_table(backfill_mod, fake_http, tmp_path):
+    out = tmp_path / "a.json"
+    fake_http(FakeSession(sequence=[FakeResponse(404, ""), FakeResponse(200, status_page())]))
+    backfill_mod.backfill(132, ["0001", "0002"], out, delay=0)
+
+    assert [r["ld_number"] for r in json.loads(out.read_text())] == ["0002"]
+    assert json.loads((tmp_path / "a-missing.json").read_text()) == ["0001"]
+
+
+def test_a_corrupt_missing_sidecar_refetches_rather_than_crashing(
+    backfill_mod, fake_http, tmp_path
+):
+    out = tmp_path / "a.json"
+    (tmp_path / "a-missing.json").write_text("{ not json")
+    http = fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    assert backfill_mod.backfill(132, ["0001"], out, delay=0)["records"] == 1
+    assert len(http.requested) == 1
+
+
 def test_a_corrupt_output_file_restarts_rather_than_crashing(backfill_mod, fake_http, tmp_path):
     out = tmp_path / "a.json"
     out.write_text("{ this is not json")

--- a/tests/unit/test_backfill_bill_status.py
+++ b/tests/unit/test_backfill_bill_status.py
@@ -6,6 +6,10 @@ the rate limit doesn't make the suite slow.
 
 import importlib.util
 import json
+import os
+import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -110,6 +114,27 @@ def test_the_delay_is_honored_at_other_rates(backfill_mod, fake_http, sleeps, tm
     fake_http(FakeSession(default=FakeResponse(200, status_page())))
     backfill_mod.backfill(132, ["0001", "0002"], tmp_path / "a.json", delay=2.5)
     assert sleeps == [2.5, 2.5]
+
+
+def test_the_default_rate_is_one_request_per_second(backfill_mod):
+    """The workflow passes no --delay, so the argparse default IS the production
+    rate against a state government server. Every other delay assertion passes
+    the value explicitly, which left this one number — the number the whole
+    design is about — with nothing behind it."""
+    args = backfill_mod.parse_args(
+        ["--session", "132", "--parquet-source", "x", "--output", "/tmp/x"]
+    )
+    assert args.delay == 1.0
+    assert backfill_mod.DEFAULT_DELAY == 1.0
+
+
+def test_the_workflow_relies_on_that_default():
+    """If the workflow ever starts passing --delay, this test should be replaced
+    by one asserting the value it passes. Until then the default is the rate."""
+    workflow = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "data-run.yml"
+    body = workflow.read_text()
+    backfill_step = body.split("scripts/backfill_bill_status.py")[1][:400]
+    assert "--delay" not in backfill_step
 
 
 def test_requests_carry_a_contactable_user_agent(backfill_mod):
@@ -279,14 +304,83 @@ def test_sustained_failure_aborts_instead_of_running_the_whole_session(
 
 def test_scattered_failures_do_not_abort_a_healthy_run(backfill_mod, fake_http, tmp_path):
     """The breaker is for a site that has stopped answering, not for one bad
-    bill every so often."""
-    good, bad = FakeResponse(200, status_page()), FakeResponse(500, "")
+    bill every so often.
+
+    Deliberately more scattered failures (30) than the threshold (10), spread
+    over 300 bills. An earlier version used 6 failures over 30 bills — under
+    the threshold, so it passed even with the on-success counter reset deleted,
+    which is the one line that makes the breaker safe for a healthy run.
+    """
+    good, bad = FakeResponse(200, status_page()), FakeResponse(403, "")
+    sequence = [bad if i % 10 == 0 else good for i in range(300)]
+    fake_http(FakeSession(sequence=sequence))
+    summary = backfill_mod.backfill(
+        132, [f"{i:04d}" for i in range(1, 301)], tmp_path / "a.json", 0
+    )
+    assert summary["aborted"] is False
+    assert summary["failed"] == 30
+    assert summary["records"] == 270
+
+
+def test_a_long_retry_after_stops_the_session_rather_than_sitting_it_out(
+    backfill_mod, fake_http, sleeps, tmp_path
+):
+    """A rate limiter naming a 300s wait, honored three times per bill, meant a
+    single LD cost ~900s. Ten of those is 150 minutes against a 120-minute job
+    timeout, so the breaker could never fire — the job just slept until it was
+    killed. A wait we are not willing to sit through ends the run instead."""
+    busy = FakeResponse(429, "")
+    busy.headers = {"Retry-After": "300"}
+    http = fake_http(FakeSession(default=busy))
+    summary = backfill_mod.backfill(
+        132, [f"{i:04d}" for i in range(1, 501)], tmp_path / "a.json", delay=1.0
+    )
+    assert summary["aborted"] is True
+    assert "Retry-After" in summary["abort_reason"]
+    assert len(http.requested) == 1, "it should stop on the first such answer"
+    assert max(sleeps, default=0) <= backfill_mod.RETRY_AFTER_ABORT
+
+
+def test_no_backoff_sleep_after_the_final_attempt(backfill_mod, fake_http, sleeps, tmp_path):
+    """The wait is a backoff before a retry. After the last attempt there is no
+    retry, so sleeping is pure dead time against the job's clock."""
+    fake_http(FakeSession(default=FakeResponse(503, "")))
+    backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=1.0)
+    # Backoff before attempts 2 and 3, none after 3, then the inter-bill delay.
+    # Asserted as an exact sequence: filtering by value silently dropped the
+    # first backoff, which happens to equal the inter-bill delay.
+    assert sleeps == [2.0, 4.0, 1.0]
+
+
+def test_no_backoff_sleep_after_the_final_attempt_on_a_network_error(
+    backfill_mod, fake_http, sleeps, tmp_path
+):
+    """Same rule on the connection-error path, which has its own sleep."""
+
+    class ExplodingSession(FakeSession):
+        def get(self, url, timeout=None):
+            self.requested.append(url)
+            raise backfill_mod.requests.ConnectionError("refused")
+
+    fake_http(ExplodingSession())
+    backfill_mod.backfill(132, ["0001"], tmp_path / "a.json", delay=1.0)
+    assert sleeps == [1.0, 2.0, 1.0]
+
+
+def test_a_missing_bill_resets_the_failure_streak(backfill_mod, fake_http, tmp_path):
+    """The two breakers count separately. A site answering "no such bill" in
+    between failures is still answering, so the failure streak must reset — or
+    scattered failures with normal gaps between them accumulate to an abort
+    that never actually happened consecutively."""
+    bad, gap = FakeResponse(403, ""), FakeResponse(200, not_found_page())
+    # Nine failures, then a plain answer, repeated: never ten in a row.
     sequence = []
-    for i in range(30):
-        sequence.append(bad if i % 5 == 0 else good)
-    # A 500 is retried MAX_ATTEMPTS times, so pad the sequence generously.
-    fake_http(FakeSession(sequence=sequence + [good] * 200))
-    summary = backfill_mod.backfill(132, [f"{i:04d}" for i in range(1, 31)], tmp_path / "a.json", 0)
+    for _ in range(12):
+        sequence.extend([bad] * 9 + [gap])
+    fake_http(FakeSession(sequence=sequence))
+    summary = backfill_mod.backfill(
+        132, [f"{i:04d}" for i in range(1, 121)], tmp_path / "a.json", delay=0
+    )
     assert summary["aborted"] is False
 
 
@@ -480,6 +574,23 @@ def test_a_truncated_checkpoint_does_not_discard_the_session(backfill_mod, fake_
     assert http.requested == []
 
 
+def test_the_temp_file_is_private_to_this_process(backfill_mod, monkeypatch, tmp_path):
+    """Two runs of the same session sharing one temp path interleave into the
+    same file and can rename corrupt JSON into place — defeating the point of
+    writing atomically. The matrix dedupe covers one dispatch, not two, nor a
+    local run alongside CI."""
+    seen = []
+    real_replace = Path.replace
+
+    def spy(self, target):
+        seen.append(self.name)
+        return real_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", spy)
+    backfill_mod.write_json(tmp_path / "a.json", [])
+    assert seen and str(os.getpid()) in seen[0]
+
+
 def test_a_write_that_dies_partway_leaves_the_previous_file_intact(
     backfill_mod, monkeypatch, tmp_path
 ):
@@ -555,15 +666,57 @@ def test_a_clean_run_exits_zero(backfill_mod, monkeypatch, fake_http, tmp_path):
     assert summary["complete"] is True
 
 
-def test_a_session_of_nonexistent_bills_still_exits_zero(
+def test_some_missing_bills_do_not_make_the_session_incomplete(
     backfill_mod, monkeypatch, fake_http, tmp_path
 ):
-    """Missing bills are a plain answer from the site, not a failure."""
-    code, summary = run_main(
-        backfill_mod, monkeypatch, fake_http, tmp_path, FakeResponse(200, not_found_page())
+    """A missing bill is a plain answer from the site, not a failure."""
+    monkeypatch.setattr(backfill_mod, "session_ld_numbers", lambda _src, _s: ["0001", "0002"])
+    fake_http(
+        FakeSession(
+            sequence=[FakeResponse(200, not_found_page()), FakeResponse(200, status_page())]
+        )
     )
+    code = backfill_mod.main(
+        ["--session", "132", "--parquet-source", "u", "--output", str(tmp_path), "--delay", "0"]
+    )
+    summary = json.loads((tmp_path / "summary-132.json").read_text())
     assert code == 0
+    assert (summary["records"], summary["no_status_page"]) == (1, 1)
     assert summary["complete"] is True
+
+
+def test_a_session_where_every_bill_is_missing_is_not_a_success(
+    backfill_mod, monkeypatch, fake_http, tmp_path
+):
+    """A wrong session number returns the identical not-found body for every LD.
+    Nothing is then outstanding, so the run reported complete with an empty
+    actions table and a green check. Enumeration comes from the parquet, so
+    every LD asked about is one we hold a document for — this many misses in a
+    row is systemic, not a sparse session."""
+    lds = [f"{i:04d}" for i in range(1, 201)]
+    http = fake_http(FakeSession(default=FakeResponse(200, not_found_page())))
+    monkeypatch.setattr(backfill_mod, "session_ld_numbers", lambda _src, _s: lds)
+    code = backfill_mod.main(
+        ["--session", "140", "--parquet-source", "u", "--output", str(tmp_path), "--delay", "0"]
+    )
+    summary = json.loads((tmp_path / "summary-140.json").read_text())
+
+    assert code == 1
+    assert summary["complete"] is False
+    assert summary["aborted"] is True
+    assert len(http.requested) == backfill_mod.MAX_CONSECUTIVE_MISSING
+    assert json.loads((tmp_path / "actions-140.json").read_text()) == []
+
+
+def test_an_empty_ld_set_is_not_a_success(backfill_mod, monkeypatch, fake_http, tmp_path):
+    """A session absent from the parquet has nothing outstanding either."""
+    monkeypatch.setattr(backfill_mod, "session_ld_numbers", lambda _src, _s: [])
+    fake_http(FakeSession(default=FakeResponse(200, status_page())))
+    code = backfill_mod.main(
+        ["--session", "133", "--parquet-source", "u", "--output", str(tmp_path)]
+    )
+    assert code == 1
+    assert json.loads((tmp_path / "summary-133.json").read_text())["complete"] is False
 
 
 def test_a_blocked_run_exits_non_zero(backfill_mod, monkeypatch, fake_http, tmp_path):
@@ -576,6 +729,42 @@ def test_a_blocked_run_exits_non_zero(backfill_mod, monkeypatch, fake_http, tmp_
     assert code == 1
     assert summary["aborted"] is True
     assert summary["complete"] is False
+
+
+def test_sigterm_still_leaves_a_summary(tmp_path):
+    """The job timeout kills with SIGTERM, and Python's default disposition
+    terminates the process WITHOUT raising — so `except BaseException` never
+    ran and a timed-out job left a partial actions table and no summary, which
+    is indistinguishable from a small complete session.
+
+    Has to be a real subprocess: the whole point is what the signal does to a
+    normal interpreter, which an in-process fake cannot show.
+    """
+    driver = tmp_path / "driver.py"
+    driver.write_text(
+        "import importlib.util, sys, time, os\n"
+        f"spec = importlib.util.spec_from_file_location('bf', {str(SCRIPT)!r})\n"
+        "bf = importlib.util.module_from_spec(spec); spec.loader.exec_module(bf)\n"
+        "bf.session_ld_numbers = lambda *_a: ['0001']\n"
+        "bf.backfill = lambda *a, **k: time.sleep(60)\n"
+        f"sys.exit(bf.main(['--session','132','--parquet-source','u','--output',{str(tmp_path)!r}]))\n"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, str(driver)], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    summary_path = tmp_path / "summary-132.json"
+    deadline = time.time() + 20
+    while not proc.poll() and time.time() < deadline:
+        time.sleep(0.1)
+        if (tmp_path / "driver.py").exists() and time.time() > deadline - 18:
+            break
+    proc.terminate()
+    proc.wait(timeout=15)
+
+    assert summary_path.exists(), "SIGTERM must not lose the summary"
+    summary = json.loads(summary_path.read_text())
+    assert summary["complete"] is False
+    assert summary["aborted"] is True
 
 
 def test_a_crash_still_leaves_a_summary_saying_it_failed(


### PR DESCRIPTION
Sprint node N3: fetch and parse bill status pages, producing the `actions` config — one record per bill carrying its legislative history (committee docket, referral, final disposition, governor's action, chaptered law).

## The thing that shaped the design

**legislature.maine.gov does not return 404.** For a bill that does not exist it answers HTTP 200 with a normal-looking page whose only tell is the heading "Cannot find requested paper". Verified on `LD=9999` and `LD=99999` for session 132, and independently reproduced by review — including the case that matters most, a **wrong session number, where every LD returns that same body**.

Two consequences that drove most of this PR:

- `is_status_page` must key on the **paper number**, not on the act title. `_parse_bill_title` falls back to the longest heading, so the error text parsed as a title and the page recorded as a real bill. Every real page sampled across sessions 121–132 carries a paper number (`SP 29`, `HP 1287`, …); the not-found page carries none.
- "No such bill" has to be detected from the page, not from an HTTP status. Detecting it from a 404 would be dead code on this host.

A 200 we cannot account for — a WAF challenge, an outage page — is kept **separate** from "no such bill". The first is transient and counts as a failure; the second is definitive and is remembered. Collapsing them would let a temporary block be recorded as "this bill does not exist" and never revisited, which is the worst outcome available here.

## Politeness, which is the part with an outside party

Twelve sessions × ~2,000 bills against a state government server. robots.txt states no `Crawl-delay` and no `Request-rate`, so the rate is our judgment, not the site's instruction.

- **1 request/second per session**, `max-parallel: 3` (agreed with the repo owner). Both are commented at their definition sites so raising either is deliberate.
- **Enumeration comes from the published parquet**, not from `billdirectory_ps.asp` — ~13 fewer paged fetches per session, and the LD set is exactly the one the actions table must join against.
- **Circuit breaker**: stops after 10 consecutive failures. Per-LD retry alone does not stop a blocked run, it only paces it — review reproduced 2,000 futile requests against a sustained 403.
- **`Retry-After` above 120s ends the session** rather than being slept through. Honoring a 300s wait three times per bill cost ~900s per LD, which meant the breaker could never fire inside the 120-minute job timeout — the job would sleep until killed.
- **50 consecutive missing bills aborts, but only while nothing has been recorded.** An earlier version aborted on the run length alone, justified by "every LD comes from the parquet, so a missing status page is anomalous by construction". **That reasoning was wrong** — the documents come from `lldc.mainelegislature.org` and the status pages from `legislature.maine.gov`, which are independent systems. Review found session 124 has a real page at LD 1800 and none at LD 1850; confirmed against the live site. A contiguous gap where the document repository outruns the status application is normal, and would have aborted a healthy session. Requiring zero records keeps the wrong-session protection (that case never records anything) while making a mid-session gap harmless.

## Reporting honestly

A partial actions table is shape-identical to a complete one, so the summary says which it is: `complete`, `aborted`, `abort_reason`, `not_attempted`. `complete` is measured against the full LD set (not the run's own todo list, which made `--limit` report success) and requires `records` to be non-empty (without which an all-missing run reported success with an empty table). `main()` exits non-zero unless the session completed, and the summary is written even when the run raises — including on the job timeout's SIGTERM, which needs an explicit handler because Python's default disposition terminates without raising.

## Resumability

Records and a `-missing.json` sidecar are checkpointed every 50 bills and written atomically (temp file + rename, PID-scoped). `--recheck-missing` loads the known set and removes an LD only when the site answers for it — rebuilding from empty meant an incomplete recheck erased everything it had not re-reached.

**Known limitation, stated rather than implied:** `data/` is gitignored and CI starts from a fresh checkout, so the resume state only helps someone running the script locally. A re-run of a failed job refetches its session. Accepted — a session is ~35 minutes against a 120-minute timeout, and the breakers stop a genuinely bad run early. Restoring the prior artifact would need a cross-run download and an `actions: read` grant.

## Tier

**Tier-2 proposed, and this needs ratifying.** `GOVERNANCE.md` lists "CI/workflows: files under `.github/`" as Tier-1 with no carve-out, and this PR touches `data-run.yml` (new `plan-backfill` and `backfill-status` jobs) and `ci.yml` (lint scope). The changes are additive and dispatch-only, but **the tier call is yours, not mine** — if you want every `.github/` edit treated as Tier-1, say so and I'll follow that from here.

Note the `backfill-status` job is `contents: read`: unlike the recon and status-sample jobs it pushes nothing, publishing through an artifact instead.

## Checks

- 461 tests passing, `ruff check src/ tests/ scripts/` clean.
- **`scripts/` added to the CI lint scope.** It was not linted at all, so these 460 lines — which run unattended against a state server — were never checked by CI, and a commit on this branch carried an F841 nobody saw.
- **Verified by mutation, not by test count.** Review demonstrated that deleting the rate limit, the timeout, the User-Agent, the checkpointing and the retry backoff each left the suite fully green. The sleep fixture now records rather than discards. Every fix in this PR is covered by a mutation that the suite catches. `DEFAULT_DELAY` is pinned because the workflow passes no `--delay`, making the argparse default the production request rate.
- **Reviewed independently across three rounds; approved.** Recommendation carried forward: dispatch one or two sessions before committing to all twelve.

## Rollback

Revert the commits. Nothing is published; the dataset is unchanged until the actions config is built from these artifacts, which is a separate step.