### PR TITLE
[Tier-1] the `actions` dataset config: legislative history keyed to the bills table

### DIFF
--- a/.github/workflows/data-run.yml
+++ b/.github/workflows/data-run.yml
@@ -34,7 +34,7 @@ on:
         required: false
         default: "132"
       run_id:
-        description: "For build-actions: the workflow run id holding the actions-<session> artifacts"
+        description: "For build-actions: space-separated run id(s) holding the actions-<session> artifacts"
         type: string
         required: false
         default: ""
@@ -508,22 +508,34 @@ jobs:
           RUN_ID: ${{ inputs.run_id }}
         run: |
           case "$RUN_ID" in
-            "" | *[!0-9]*)
-              echo "::error::build-actions needs run_id: the numeric id of the run holding the actions-<session> artifacts"
+            "" | *[!0-9\ ]*)
+              echo "::error::build-actions needs run_id: space-separated numeric run id(s) holding the actions-<session> artifacts"
               exit 1
               ;;
           esac
 
+      # Several run ids, because the twelve sessions do not have to come from
+      # one run: a session that failed and was re-dispatched has its artifact
+      # on a different run, and re-running all twelve to consolidate them would
+      # mean 24,000 more requests at the state's server to avoid a loop here.
+      #
+      # `gh run download` rather than actions/download-artifact, which takes a
+      # single run-id. Each artifact lands in its own directory, which
+      # session_artifacts() finds recursively. A later run wins on collision,
+      # which is what re-running a session is for.
       - name: Download the backfill artifacts
-        uses: actions/download-artifact@v4
-        with:
-          # Each session uploaded its own `actions-<session>` artifact; the
-          # pattern collects them all into per-artifact subdirectories, which
-          # session_artifacts() searches recursively.
-          pattern: actions-*
-          path: data/actions
-          run-id: ${{ inputs.run_id }}
-          github-token: ${{ github.token }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_IDS: ${{ inputs.run_id }}
+        run: |
+          set -e
+          mkdir -p data/actions
+          for id in $RUN_IDS; do
+            echo "::group::run $id"
+            gh run download "$id" --repo "$GITHUB_REPOSITORY" --pattern 'actions-*' --dir data/actions
+            echo "::endgroup::"
+          done
+          find data/actions -name 'actions-*.json' -o -name 'summary-*.json' | sort
 
       - name: Build
         run: |

--- a/.github/workflows/data-run.yml
+++ b/.github/workflows/data-run.yml
@@ -520,22 +520,28 @@ jobs:
       # mean 24,000 more requests at the state's server to avoid a loop here.
       #
       # `gh run download` rather than actions/download-artifact, which takes a
-      # single run-id. Each artifact lands in its own directory, which
-      # session_artifacts() finds recursively. A later run wins on collision,
-      # which is what re-running a session is for.
+      # single run-id.
+      #
+      # Each run gets its OWN directory. Two runs can carry an artifact of the
+      # same name -- session 126 failed in the first full backfill and was
+      # re-dispatched, so `actions-126` exists on both -- and gh refuses to
+      # extract over an existing file rather than overwriting it, which failed
+      # the whole download. resolve_sessions() picks the complete copy.
       - name: Download the backfill artifacts
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_IDS: ${{ inputs.run_id }}
         run: |
           set -e
-          mkdir -p data/actions
           for id in $RUN_IDS; do
             echo "::group::run $id"
-            gh run download "$id" --repo "$GITHUB_REPOSITORY" --pattern 'actions-*' --dir data/actions
+            mkdir -p "data/actions/run-$id"
+            gh run download "$id" --repo "$GITHUB_REPOSITORY" \
+              --pattern 'actions-*' --dir "data/actions/run-$id"
             echo "::endgroup::"
           done
-          find data/actions -name 'actions-*.json' -o -name 'summary-*.json' | sort
+          echo "Collected:"
+          find data/actions -name 'actions-*.json' | sort
 
       - name: Build
         run: |

--- a/.github/workflows/data-run.yml
+++ b/.github/workflows/data-run.yml
@@ -26,12 +26,18 @@ on:
           - diagnose-sponsors
           - fetch-status-sample
           - run-matching
+          - build-actions
           - custom
       sessions:
         description: "Space-separated session numbers (e.g. '132' or '132 121')"
         type: string
         required: false
         default: "132"
+      run_id:
+        description: "For build-actions: the workflow run id holding the actions-<session> artifacts"
+        type: string
+        required: false
+        default: ""
       extra_args:
         description: "Extra args (run-matching passthrough, or full command for 'custom': runs `uv run <extra_args>`)"
         type: string
@@ -476,6 +482,76 @@ jobs:
   # Escape hatch: run an arbitrary `uv run <extra_args>` command with full
   # network access. Dispatch-only, so only collaborators with write access can
   # trigger it; running arbitrary input is the point of this job.
+  # Turn the backfill artifacts into the published `actions` config. Separate
+  # from the backfill so a session can be re-run without rebuilding everything,
+  # and separate from publishing so a human sees the parquet before it ships --
+  # uploading is Tier-1 and goes through the huggingface-publish gate.
+  build-actions:
+    if: inputs.task == 'build-actions'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read # download-artifact needs this to reach ANOTHER run's artifacts
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Validate run_id
+        env:
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          case "$RUN_ID" in
+            "" | *[!0-9]*)
+              echo "::error::build-actions needs run_id: the numeric id of the run holding the actions-<session> artifacts"
+              exit 1
+              ;;
+          esac
+
+      - name: Download the backfill artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # Each session uploaded its own `actions-<session>` artifact; the
+          # pattern collects them all into per-artifact subdirectories, which
+          # session_artifacts() searches recursively.
+          pattern: actions-*
+          path: data/actions
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Build
+        run: |
+          uv run python scripts/build_actions_config.py \
+            --input data/actions \
+            --output data/actions-parquet
+
+      - name: Summarize
+        if: always()
+        run: |
+          F="data/actions-parquet/build-summary.json"
+          if [ -f "$F" ]; then
+            {
+              echo "### actions config"
+              echo '```json'
+              cat "$F"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload the built config
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: actions-config
+          path: data/actions-parquet/
+          if-no-files-found: warn
+
   custom:
     if: inputs.task == 'custom'
     runs-on: ubuntu-latest

--- a/scripts/build_actions_config.py
+++ b/scripts/build_actions_config.py
@@ -28,19 +28,22 @@ from maine_bills.actions_config import (  # noqa: E402
     ActionsConfigError,
     build_session,
     orphan_summaries,
+    resolve_sessions,
 )
 
 logger = logging.getLogger("build_actions_config")
 
 
 def session_artifacts(input_dir: Path) -> list[Path]:
-    """Every `actions-<session>.json` under the input directory, in order.
+    """One records file per session, in session order.
 
-    Searched recursively: downloading N artifacts from a workflow run gives
-    `<dir>/actions-<session>/actions-<session>.json`, while a local run writes
-    them flat. Both should work without the caller having to care.
+    Searched recursively: artifacts from a workflow run arrive nested, a local
+    run writes them flat, and several runs are downloaded into per-run
+    directories. Duplicates across runs are resolved by resolve_sessions --
+    a complete copy beats an incomplete one.
     """
-    return sorted(input_dir.rglob("actions-*.json"), key=lambda p: p.name)
+    resolved = resolve_sessions(input_dir)
+    return [resolved[session] for session in sorted(resolved)]
 
 
 def build(input_dir: Path, output_dir: Path, strict: bool = True) -> dict:

--- a/scripts/build_actions_config.py
+++ b/scripts/build_actions_config.py
@@ -24,7 +24,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from maine_bills.actions_config import ActionsConfigError, build_session  # noqa: E402
+from maine_bills.actions_config import (  # noqa: E402
+    ActionsConfigError,
+    build_session,
+    orphan_summaries,
+)
 
 logger = logging.getLogger("build_actions_config")
 
@@ -45,7 +49,23 @@ def build(input_dir: Path, output_dir: Path, strict: bool = True) -> dict:
     if not artifacts:
         raise ActionsConfigError(f"No actions-*.json under {input_dir}")
 
-    built, skipped, total_rows, total_actions = [], [], 0, 0
+    # A crashed run uploads a summary with no records beside it. Globbing for
+    # records alone cannot see that, so the build would silently produce one
+    # session fewer and report success.
+    orphans = orphan_summaries(input_dir)
+    if orphans:
+        message = (
+            f"Sessions {orphans} have a summary but no records — their runs did not get "
+            f"far enough to write one. Re-run the backfill for them before building."
+        )
+        if strict:
+            raise ActionsConfigError(message)
+        logger.error(message)
+        skipped_orphans = [f"session-{s}" for s in orphans]
+    else:
+        skipped_orphans = []
+
+    built, skipped, total_rows, total_actions = [], list(skipped_orphans), 0, 0
     for path in artifacts:
         try:
             frame = build_session(path)

--- a/scripts/build_actions_config.py
+++ b/scripts/build_actions_config.py
@@ -1,0 +1,124 @@
+"""Turn backfill artifacts into the published `actions` config (sprint node N3).
+
+Reads the per-session JSON the backfill wrote (`actions-<session>.json` beside
+`summary-<session>.json`) and writes one parquet per session, laid out the same
+way the bills config is: `<out>/<session>/train-00000-of-00001.parquet`.
+
+Refuses to build a session whose summary does not say `complete`. A partial
+actions table looks exactly like a complete one for a smaller session, so the
+summary is the only thing that can tell them apart — see actions_config.py.
+
+Publishing is deliberately NOT part of this. It writes parquet locally and
+stops; uploading is Tier-1 and goes through the `huggingface-publish` gate.
+
+Usage:
+    uv run python scripts/build_actions_config.py \\
+        --input data/actions --output data/actions-parquet
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from maine_bills.actions_config import ActionsConfigError, build_session  # noqa: E402
+
+logger = logging.getLogger("build_actions_config")
+
+
+def session_artifacts(input_dir: Path) -> list[Path]:
+    """Every `actions-<session>.json` under the input directory, in order.
+
+    Searched recursively: downloading N artifacts from a workflow run gives
+    `<dir>/actions-<session>/actions-<session>.json`, while a local run writes
+    them flat. Both should work without the caller having to care.
+    """
+    return sorted(input_dir.rglob("actions-*.json"), key=lambda p: p.name)
+
+
+def build(input_dir: Path, output_dir: Path, strict: bool = True) -> dict:
+    """Build every session found. Returns a summary of what was written."""
+    artifacts = session_artifacts(input_dir)
+    if not artifacts:
+        raise ActionsConfigError(f"No actions-*.json under {input_dir}")
+
+    built, skipped, total_rows, total_actions = [], [], 0, 0
+    for path in artifacts:
+        try:
+            frame = build_session(path)
+        except ActionsConfigError as e:
+            if strict:
+                raise
+            # --no-strict exists so an operator can publish the sessions that
+            # are ready while one is re-running, rather than being blocked on
+            # all-or-nothing. It is not the default, because the failure mode
+            # it enables -- shipping eleven sessions and forgetting the
+            # twelfth -- is quiet.
+            logger.error(f"Skipping {path.name}: {e}")
+            skipped.append(path.name)
+            continue
+
+        session = int(frame["session"].iloc[0])
+        session_dir = output_dir / str(session)
+        session_dir.mkdir(parents=True, exist_ok=True)
+        out_path = session_dir / "train-00000-of-00001.parquet"
+        frame.to_parquet(out_path, index=False)
+
+        rows, actions = len(frame), int(frame["action_count"].sum())
+        total_rows += rows
+        total_actions += actions
+        built.append({"session": session, "rows": rows, "actions": actions})
+        logger.info(f"Session {session}: {rows} bills, {actions} actions -> {out_path}")
+
+    return {
+        "sessions_built": len(built),
+        "sessions_skipped": skipped,
+        "rows": total_rows,
+        "actions": total_actions,
+        "per_session": built,
+    }
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--input", type=Path, required=True, help="Directory holding the backfill artifacts"
+    )
+    parser.add_argument("--output", type=Path, required=True, help="Where to write the parquet")
+    parser.add_argument(
+        "--no-strict",
+        dest="strict",
+        action="store_false",
+        help="Skip sessions that are incomplete rather than failing. Off by default: "
+        "publishing eleven of twelve sessions is a quiet way to ship a gap.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
+    args = parse_args(argv)
+
+    try:
+        summary = build(args.input, args.output, strict=args.strict)
+    except ActionsConfigError as e:
+        logger.error(str(e))
+        return 1
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    (args.output / "build-summary.json").write_text(json.dumps(summary, indent=2))
+    logger.info(
+        f"Built {summary['sessions_built']} sessions, "
+        f"{summary['rows']} bills, {summary['actions']} actions"
+    )
+    if summary["sessions_skipped"]:
+        logger.warning(f"Skipped: {', '.join(summary['sessions_skipped'])}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/maine_bills/actions_config.py
+++ b/src/maine_bills/actions_config.py
@@ -22,6 +22,7 @@ recorded as a failure and excluded rather than written as an empty row.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pandas as pd
@@ -55,6 +56,27 @@ class ActionsConfigError(ValueError):
     """A backfill artifact is not usable as a published config."""
 
 
+def _read_json(path: Path):
+    """Parse an artifact, reporting a bad one as an ActionsConfigError.
+
+    A truncated or half-written JSON file is one of the concrete things this
+    module exists to catch, and letting json.JSONDecodeError escape meant
+    catching it nowhere: the CLI only handles ActionsConfigError, so a
+    truncated artifact produced a bare traceback instead of a message naming
+    the file, and --no-strict could not skip past it to build the other
+    eleven sessions.
+    """
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise ActionsConfigError(
+            f"{path}: not valid JSON ({e}). The artifact is truncated or was written "
+            f"by a run that died mid-write; re-run the backfill for this session."
+        ) from e
+    except OSError as e:
+        raise ActionsConfigError(f"{path}: cannot be read ({e})") from e
+
+
 def load_backfill(path: Path) -> list[dict]:
     """Read one session's backfill output, refusing anything incomplete.
 
@@ -63,7 +85,7 @@ def load_backfill(path: Path) -> list[dict]:
     is shape-identical to a complete one. Publishing that would silently ship a
     session with bills missing and no way to tell from the data.
     """
-    records = json.loads(path.read_text())
+    records = _read_json(path)
     if not isinstance(records, list):
         raise ActionsConfigError(f"{path}: expected a list of records")
 
@@ -75,7 +97,12 @@ def load_backfill(path: Path) -> list[dict]:
             f"finished run."
         )
 
-    summary = json.loads(summary_path.read_text())
+    summary = _read_json(summary_path)
+    if not isinstance(summary, dict):
+        raise ActionsConfigError(
+            f"{summary_path}: expected an object, not {type(summary).__name__}"
+        )
+
     if not summary.get("complete"):
         raise ActionsConfigError(
             f"{path}: session {summary.get('session')} is not complete "
@@ -109,8 +136,24 @@ def is_complete(records_path: Path) -> bool:
         return False
     try:
         return bool(json.loads(summary_path.read_text()).get("complete"))
-    except (json.JSONDecodeError, TypeError):
+    except (json.JSONDecodeError, TypeError, AttributeError, OSError):
+        # A summary that cannot be read is not evidence of completeness. The
+        # artifact still reaches load_backfill, which reports WHY.
         return False
+
+
+def _natural_key(path: Path) -> tuple:
+    """Sort key that orders embedded numbers numerically.
+
+    Plain lexicographic ordering puts `run-9` after `run-10`, so "the later run
+    wins" silently meant "the run whose id sorts last as text". Today's GitHub
+    run ids are all the same width, which hides the bug — a local input
+    directory numbered run-1..run-12 does not.
+    """
+    return tuple(
+        (1, int(part), "") if part.isdigit() else (0, 0, part)
+        for part in re.split(r"(\d+)", str(path))
+    )
 
 
 def resolve_sessions(input_dir: Path) -> dict[int, Path]:
@@ -120,11 +163,11 @@ def resolve_sessions(input_dir: Path) -> dict[int, Path]:
     session 126 failed in the first full backfill and was re-dispatched, so
     both runs carry an `actions-126` artifact. A complete copy always wins over
     an incomplete one — that is what re-running a session means. Between two
-    equally complete copies the later path wins, which with per-run directories
-    is the later run.
+    equally complete copies the later run wins, ordered numerically on the run
+    id in the path rather than as text.
     """
     candidates: dict[int, list[Path]] = {}
-    for path in sorted(input_dir.rglob("actions-*.json")):
+    for path in sorted(input_dir.rglob("actions-*.json"), key=_natural_key):
         session = session_of(path)
         if session is not None:
             candidates.setdefault(session, []).append(path)
@@ -159,10 +202,19 @@ def orphan_summaries(input_dir: Path) -> list[int]:
     return sorted(missing)
 
 
+# Columns whose dtype is pinned rather than inferred. Applied to the empty
+# frame too: pandas infers `object` for every column of an empty frame, so an
+# empty session written to parquet would carry a different schema than every
+# other session in the same config -- int64 vs object on the join key's
+# neighbours is exactly the kind of drift a reader hits only at load time.
+_DTYPES = {"session": "int64", "ld_number": "string", "action_count": "int64"}
+
+
 def build_frame(records: list[dict]) -> pd.DataFrame:
     """One session's records as a DataFrame with the published column order."""
     if not records:
-        return pd.DataFrame({name: pd.Series(dtype="object") for name in COLUMNS})
+        empty = pd.DataFrame({name: pd.Series(dtype="object") for name in COLUMNS})
+        return empty.astype(_DTYPES)
 
     rows = []
     for record in records:
@@ -180,19 +232,32 @@ def build_frame(records: list[dict]) -> pd.DataFrame:
         row["actions"] = [{f: a.get(f) for f in ACTION_FIELDS} for a in record["actions"]]
         rows.append(row)
 
-    frame = pd.DataFrame(rows, columns=COLUMNS)
-    frame["session"] = frame["session"].astype("int64")
-    frame["ld_number"] = frame["ld_number"].astype("string")
-    frame["action_count"] = frame["action_count"].astype("int64")
-    return frame
+    return pd.DataFrame(rows, columns=COLUMNS).astype(_DTYPES)
 
 
 def build_session(path: Path) -> pd.DataFrame:
-    """Load and validate one session's backfill artifact into a frame."""
+    """Load and validate one session's backfill artifact into a frame.
+
+    Never returns an empty frame. `build_frame([])` is a legitimate primitive
+    -- it is what gives an empty frame the published dtypes -- but a *session*
+    with no bills is not a small session, it is a broken run: enumeration reads
+    the LD set from the published parquet, so zero records means enumeration
+    came back empty and the backfill still declared itself complete. Publishing
+    that is the silent gap the completeness check exists to prevent, reaching
+    the same end by a different road.
+
+    Refusing here also keeps the builder simple: it can read the session number
+    off the frame without an empty-frame branch, and --no-strict downgrades
+    this to a skip like any other per-session refusal.
+    """
     frame = build_frame(load_backfill(path))
 
     if frame.empty:
-        return frame
+        raise ActionsConfigError(
+            f"{path}: complete but has no records. A Maine session has ~2,000 bills; "
+            f"zero means enumeration returned nothing and the run finished anyway. "
+            f"Re-run the backfill for this session."
+        )
 
     sessions = frame["session"].unique()
     if len(sessions) != 1:

--- a/src/maine_bills/actions_config.py
+++ b/src/maine_bills/actions_config.py
@@ -94,8 +94,50 @@ def load_backfill(path: Path) -> list[dict]:
     return records
 
 
+def session_of(path: Path) -> int | None:
+    """The session number in an `actions-<n>.json` / `summary-<n>.json` name."""
+    try:
+        return int(path.stem.split("-")[-1])
+    except ValueError:  # pragma: no cover - defensive
+        return None
+
+
+def is_complete(records_path: Path) -> bool:
+    """Whether this artifact's summary reports a finished session."""
+    summary_path = records_path.with_name(records_path.name.replace("actions-", "summary-"))
+    if not summary_path.exists():
+        return False
+    try:
+        return bool(json.loads(summary_path.read_text()).get("complete"))
+    except (json.JSONDecodeError, TypeError):
+        return False
+
+
+def resolve_sessions(input_dir: Path) -> dict[int, Path]:
+    """One records file per session, choosing between duplicates.
+
+    A session can appear more than once when artifacts come from several runs:
+    session 126 failed in the first full backfill and was re-dispatched, so
+    both runs carry an `actions-126` artifact. A complete copy always wins over
+    an incomplete one — that is what re-running a session means. Between two
+    equally complete copies the later path wins, which with per-run directories
+    is the later run.
+    """
+    candidates: dict[int, list[Path]] = {}
+    for path in sorted(input_dir.rglob("actions-*.json")):
+        session = session_of(path)
+        if session is not None:
+            candidates.setdefault(session, []).append(path)
+
+    resolved = {}
+    for session, paths in candidates.items():
+        complete = [p for p in paths if is_complete(p)]
+        resolved[session] = (complete or paths)[-1]
+    return resolved
+
+
 def orphan_summaries(input_dir: Path) -> list[int]:
-    """Sessions that have a summary but no records file.
+    """Sessions with a summary but no records file ANYWHERE in the input.
 
     This is what a crashed run leaves behind: session 126 of the first full
     backfill died on a rate limit during enumeration and uploaded a summary
@@ -103,15 +145,17 @@ def orphan_summaries(input_dir: Path) -> list[int]:
     find it, so the build would quietly produce eleven sessions and report
     success — the exact silent gap the completeness check exists to prevent,
     arriving through the one path that check cannot see.
+
+    Scoped across the whole input rather than per-directory, because a session
+    whose failed attempt is present alongside its successful re-run is not a
+    gap; it is the re-run working as intended.
     """
-    missing = []
-    for summary_path in input_dir.rglob("summary-*.json"):
-        records_path = summary_path.with_name(summary_path.name.replace("summary-", "actions-"))
-        if not records_path.exists():
-            try:
-                missing.append(int(summary_path.stem.split("-")[-1]))
-            except ValueError:  # pragma: no cover - defensive
-                continue
+    have_records = set(resolve_sessions(input_dir))
+    missing = {
+        session
+        for summary_path in input_dir.rglob("summary-*.json")
+        if (session := session_of(summary_path)) is not None and session not in have_records
+    }
     return sorted(missing)
 
 

--- a/src/maine_bills/actions_config.py
+++ b/src/maine_bills/actions_config.py
@@ -1,0 +1,145 @@
+"""The `actions` dataset config: legislative history, keyed to the bills table.
+
+One row per bill, carrying the bill-level status fields and its committee
+docket as a nested list. That shape rather than one-row-per-action because the
+bill-level fields (committee, final disposition, chaptered law) belong to the
+bill, not to any single docket row — a long table would repeat them on every
+row and invite disagreement between copies. Consumers who want long format can
+explode `actions` in one line; going the other way means a groupby and a
+reconstruction.
+
+**Join key.** `(session, ld_number)`, matching the bills config exactly.
+`ld_number` is zero-padded there and here. Amendments in the bills table share
+their parent's LD, so the join is one-to-many from this side: a bill's status
+describes the bill, not each printed document.
+
+Nulls are meaningful and are never filled in. A bill with no committee referral
+has `committee = None`, which is different from a bill whose referral we failed
+to parse — the latter does not exist, because a page that does not parse is
+recorded as a failure and excluded rather than written as an empty row.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+# Column order for the published parquet. Explicit rather than derived from a
+# dict, so adding a field to the backfill record cannot silently reorder or
+# introduce a column in the published schema without this file changing too.
+COLUMNS = [
+    "session",
+    "ld_number",
+    "paper",
+    "title",
+    "flags",
+    "committee",
+    "referred_date",
+    "final_disposition",
+    "final_disposition_date",
+    "governor_action",
+    "governor_action_date",
+    "chaptered_law",
+    "actions",
+    "action_count",
+    "source_url",
+]
+
+# The nested action struct. Same reasoning as COLUMNS.
+ACTION_FIELDS = ["date", "action", "result", "raw_date"]
+
+
+class ActionsConfigError(ValueError):
+    """A backfill artifact is not usable as a published config."""
+
+
+def load_backfill(path: Path) -> list[dict]:
+    """Read one session's backfill output, refusing anything incomplete.
+
+    The summary sitting beside the records is what makes this safe: a run that
+    aborted or failed writes a summary saying so, and its partial actions table
+    is shape-identical to a complete one. Publishing that would silently ship a
+    session with bills missing and no way to tell from the data.
+    """
+    records = json.loads(path.read_text())
+    if not isinstance(records, list):
+        raise ActionsConfigError(f"{path}: expected a list of records")
+
+    summary_path = path.with_name(path.name.replace("actions-", "summary-"))
+    if not summary_path.exists():
+        raise ActionsConfigError(
+            f"{path}: no summary beside it ({summary_path.name}). A run always writes one, "
+            f"even when it crashes, so its absence means this artifact is not from a "
+            f"finished run."
+        )
+
+    summary = json.loads(summary_path.read_text())
+    if not summary.get("complete"):
+        raise ActionsConfigError(
+            f"{path}: session {summary.get('session')} is not complete "
+            f"(aborted={summary.get('aborted')}, failed={summary.get('failed')}, "
+            f"not_attempted={summary.get('not_attempted')}, "
+            f"reason={summary.get('abort_reason')}). Re-run the backfill for it; "
+            f"publishing a partial session is indistinguishable from a small one."
+        )
+
+    if len(records) != summary.get("records"):
+        raise ActionsConfigError(
+            f"{path}: {len(records)} records but the summary claims "
+            f"{summary.get('records')}. The two were written by the same run, so a "
+            f"disagreement means one of the files is truncated."
+        )
+    return records
+
+
+def build_frame(records: list[dict]) -> pd.DataFrame:
+    """One session's records as a DataFrame with the published column order."""
+    if not records:
+        return pd.DataFrame({name: pd.Series(dtype="object") for name in COLUMNS})
+
+    rows = []
+    for record in records:
+        missing = [c for c in COLUMNS if c not in record]
+        if missing:
+            raise ActionsConfigError(
+                f"record {record.get('ld_number')!r} is missing {missing}; the backfill "
+                f"and this config have drifted apart"
+            )
+        row = {c: record[c] for c in COLUMNS}
+        # Normalize the nested structs so every row has identical keys in the
+        # same order. Parquet infers the struct from the data, and a record
+        # whose actions happen to omit a key would otherwise change the
+        # published schema for the whole file.
+        row["actions"] = [{f: a.get(f) for f in ACTION_FIELDS} for a in record["actions"]]
+        rows.append(row)
+
+    frame = pd.DataFrame(rows, columns=COLUMNS)
+    frame["session"] = frame["session"].astype("int64")
+    frame["ld_number"] = frame["ld_number"].astype("string")
+    frame["action_count"] = frame["action_count"].astype("int64")
+    return frame
+
+
+def build_session(path: Path) -> pd.DataFrame:
+    """Load and validate one session's backfill artifact into a frame."""
+    frame = build_frame(load_backfill(path))
+
+    if frame.empty:
+        return frame
+
+    sessions = frame["session"].unique()
+    if len(sessions) != 1:
+        raise ActionsConfigError(f"{path}: expected one session, found {sorted(sessions)}")
+
+    duplicates = frame["ld_number"][frame["ld_number"].duplicated()].tolist()
+    if duplicates:
+        # The join key has to be unique on this side or a join silently
+        # multiplies rows in the bills table.
+        raise ActionsConfigError(f"{path}: duplicate ld_number values {duplicates[:10]}")
+
+    if (frame["action_count"] != frame["actions"].map(len)).any():
+        raise ActionsConfigError(f"{path}: action_count disagrees with the actions list")
+
+    return frame

--- a/src/maine_bills/actions_config.py
+++ b/src/maine_bills/actions_config.py
@@ -94,6 +94,27 @@ def load_backfill(path: Path) -> list[dict]:
     return records
 
 
+def orphan_summaries(input_dir: Path) -> list[int]:
+    """Sessions that have a summary but no records file.
+
+    This is what a crashed run leaves behind: session 126 of the first full
+    backfill died on a rate limit during enumeration and uploaded a summary
+    with no `actions-126.json` beside it. Globbing for records alone would not
+    find it, so the build would quietly produce eleven sessions and report
+    success — the exact silent gap the completeness check exists to prevent,
+    arriving through the one path that check cannot see.
+    """
+    missing = []
+    for summary_path in input_dir.rglob("summary-*.json"):
+        records_path = summary_path.with_name(summary_path.name.replace("summary-", "actions-"))
+        if not records_path.exists():
+            try:
+                missing.append(int(summary_path.stem.split("-")[-1]))
+            except ValueError:  # pragma: no cover - defensive
+                continue
+    return sorted(missing)
+
+
 def build_frame(records: list[dict]) -> pd.DataFrame:
     """One session's records as a DataFrame with the published column order."""
     if not records:

--- a/tests/unit/test_actions_config.py
+++ b/tests/unit/test_actions_config.py
@@ -1,0 +1,193 @@
+"""Tests for the `actions` dataset config.
+
+The record fixture below is the exact shape `backfill_bill_status.to_record`
+writes — if the two drift apart, `build_frame` raises rather than publishing a
+config with a missing column.
+"""
+
+import json
+
+import pytest
+
+from maine_bills.actions_config import (
+    ACTION_FIELDS,
+    COLUMNS,
+    ActionsConfigError,
+    build_frame,
+    build_session,
+    load_backfill,
+)
+
+
+def record(ld="0001", session=132, actions=None, **overrides):
+    actions = (
+        [{"date": "2025-01-15", "action": "Voted", "result": "OTP", "raw_date": "Jan 15, 2025"}]
+        if actions is None
+        else actions
+    )
+    base = {
+        "session": session,
+        "ld_number": ld,
+        "paper": "SP 29",
+        "title": "An Act To Do A Thing",
+        "flags": ["EMERGENCY"],
+        "committee": "Judiciary",
+        "referred_date": "2025-01-10",
+        "final_disposition": "PUBLIC LAW",
+        "final_disposition_date": "2025-06-01",
+        "governor_action": "Signed",
+        "governor_action_date": "2025-06-05",
+        "chaptered_law": "ACTPUB Chapter 33",
+        "actions": actions,
+        "action_count": len(actions),
+        "source_url": "https://legislature.maine.gov/legis/bills/display_ps.asp?LD=1&snum=132",
+    }
+    base.update(overrides)
+    return base
+
+
+def write_session(tmp_path, session=132, records=None, summary=None):
+    """Write an artifact pair the way a real backfill run does."""
+    records = [record()] if records is None else records
+    actions_path = tmp_path / f"actions-{session}.json"
+    actions_path.write_text(json.dumps(records))
+    full = {
+        "session": session,
+        "records": len(records),
+        "complete": True,
+        "aborted": False,
+        "failed": 0,
+        "not_attempted": 0,
+        "abort_reason": None,
+    }
+    full.update(summary or {})
+    (tmp_path / f"summary-{session}.json").write_text(json.dumps(full))
+    return actions_path
+
+
+# --- the contract with the backfill ---
+
+
+def test_the_published_columns_match_what_the_backfill_writes(tmp_path):
+    frame = build_session(write_session(tmp_path))
+    assert list(frame.columns) == COLUMNS
+
+
+def test_a_record_missing_a_column_is_refused_not_published(tmp_path):
+    """If to_record and this config drift apart, the config must not quietly
+    ship a column of nulls."""
+    incomplete = record()
+    del incomplete["chaptered_law"]
+    path = write_session(tmp_path, records=[incomplete])
+    with pytest.raises(ActionsConfigError, match="chaptered_law"):
+        build_session(path)
+
+
+def test_nested_actions_have_identical_keys_in_every_row(tmp_path):
+    """Parquet infers the struct from the data, so a row whose action omits a
+    key would change the published schema for the whole file."""
+    sparse = record(ld="0002", actions=[{"action": "Filed"}])
+    frame = build_session(write_session(tmp_path, records=[record(), sparse]))
+    for row in frame["actions"]:
+        for action in row:
+            assert list(action.keys()) == ACTION_FIELDS
+
+
+# --- the join key, which is the point of the config ---
+
+
+def test_the_join_key_is_padded_the_way_the_bills_config_is(tmp_path):
+    frame = build_session(write_session(tmp_path, records=[record(ld="0042")]))
+    assert frame["ld_number"].iloc[0] == "0042"
+    assert frame["ld_number"].dtype == "string"
+
+
+def test_a_duplicate_ld_is_refused(tmp_path):
+    """A repeated key silently multiplies rows when joined to the bills table."""
+    path = write_session(tmp_path, records=[record(ld="0001"), record(ld="0001")])
+    with pytest.raises(ActionsConfigError, match="duplicate"):
+        build_session(path)
+
+
+def test_a_mixed_session_artifact_is_refused(tmp_path):
+    path = write_session(tmp_path, records=[record(session=132), record(ld="0002", session=131)])
+    with pytest.raises(ActionsConfigError, match="one session"):
+        build_session(path)
+
+
+def test_action_count_must_agree_with_the_actions_list(tmp_path):
+    path = write_session(tmp_path, records=[record(action_count=99)])
+    with pytest.raises(ActionsConfigError, match="action_count"):
+        build_session(path)
+
+
+# --- refusing to publish a partial session, which is the real hazard ---
+
+
+def test_an_incomplete_session_is_refused(tmp_path):
+    """A partial actions table is shape-identical to a complete one for a
+    smaller session. The summary is the only thing that can tell them apart."""
+    path = write_session(tmp_path, summary={"complete": False, "failed": 7})
+    with pytest.raises(ActionsConfigError, match="not complete"):
+        build_session(path)
+
+
+def test_an_aborted_session_is_refused(tmp_path):
+    path = write_session(
+        tmp_path,
+        summary={"complete": False, "aborted": True, "abort_reason": "10 consecutive failures"},
+    )
+    with pytest.raises(ActionsConfigError, match="10 consecutive failures"):
+        build_session(path)
+
+
+def test_an_artifact_with_no_summary_is_refused(tmp_path):
+    """Every run writes a summary, even when it crashes — so its absence means
+    this did not come from a finished run at all."""
+    path = tmp_path / "actions-132.json"
+    path.write_text(json.dumps([record()]))
+    with pytest.raises(ActionsConfigError, match="no summary"):
+        build_session(path)
+
+
+def test_a_truncated_records_file_is_caught_by_the_summary(tmp_path):
+    """Both files come from the same run, so a count disagreement means one of
+    them is truncated."""
+    path = write_session(tmp_path, records=[record()], summary={"records": 2041})
+    with pytest.raises(ActionsConfigError, match="truncated"):
+        build_session(path)
+
+
+# --- shapes that are legitimate and must survive ---
+
+
+def test_a_bill_with_no_docket_is_a_valid_row(tmp_path):
+    frame = build_session(write_session(tmp_path, records=[record(actions=[], action_count=0)]))
+    assert len(frame) == 1
+    assert frame["action_count"].iloc[0] == 0
+
+
+def test_nulls_are_preserved_rather_than_filled(tmp_path):
+    """A bill with no committee referral is different from one we failed to
+    parse; the latter never reaches here."""
+    sparse = record(committee=None, chaptered_law=None, governor_action=None)
+    frame = build_session(write_session(tmp_path, records=[sparse]))
+    assert frame["committee"].iloc[0] is None
+    assert frame["chaptered_law"].iloc[0] is None
+
+
+def test_an_empty_session_still_has_the_published_columns(tmp_path):
+    frame = build_session(write_session(tmp_path, records=[], summary={"records": 0}))
+    assert list(frame.columns) == COLUMNS
+    assert frame.empty
+
+
+def test_load_backfill_rejects_a_non_list(tmp_path):
+    (tmp_path / "actions-132.json").write_text(json.dumps({"not": "a list"}))
+    (tmp_path / "summary-132.json").write_text(json.dumps({"complete": True, "records": 0}))
+    with pytest.raises(ActionsConfigError, match="list of records"):
+        load_backfill(tmp_path / "actions-132.json")
+
+
+def test_build_frame_on_no_records_is_not_an_error():
+    assert build_frame([]).empty

--- a/tests/unit/test_actions_config.py
+++ b/tests/unit/test_actions_config.py
@@ -176,10 +176,60 @@ def test_nulls_are_preserved_rather_than_filled(tmp_path):
     assert frame["chaptered_law"].iloc[0] is None
 
 
-def test_an_empty_session_still_has_the_published_columns(tmp_path):
-    frame = build_session(write_session(tmp_path, records=[], summary={"records": 0}))
+def test_an_empty_frame_carries_the_published_columns_and_dtypes():
+    """pandas infers `object` for every column of an empty frame, so an empty
+    session written to parquet would carry a different schema than every other
+    session in the config."""
+    frame = build_frame([])
     assert list(frame.columns) == COLUMNS
     assert frame.empty
+    assert frame["session"].dtype == "int64"
+    assert frame["ld_number"].dtype == "string"
+    assert frame["action_count"].dtype == "int64"
+
+
+def test_the_empty_and_populated_frames_agree_on_dtype():
+    """The two paths build the frame differently; they must not disagree."""
+    populated = build_frame([record()])
+    empty = build_frame([])
+    for column in ("session", "ld_number", "action_count"):
+        assert empty[column].dtype == populated[column].dtype
+
+
+def test_a_complete_session_with_no_records_is_refused(tmp_path):
+    """Enumeration reads the LD set from the published parquet, so zero records
+    is not a small session — it is enumeration returning nothing and the run
+    declaring itself complete anyway."""
+    path = write_session(tmp_path, records=[], summary={"records": 0})
+    with pytest.raises(ActionsConfigError, match="no records"):
+        build_session(path)
+
+
+# --- artifacts that are damaged rather than incomplete ---
+
+
+def test_a_corrupt_records_file_is_reported_not_raised_raw(tmp_path):
+    """The CLI only handles ActionsConfigError, so a bare JSONDecodeError meant
+    a traceback instead of a message naming the file — and --no-strict could not
+    skip past it to build the other eleven sessions."""
+    write_session(tmp_path)
+    (tmp_path / "actions-132.json").write_text('[{"session": 132, ')
+    with pytest.raises(ActionsConfigError, match="not valid JSON"):
+        build_session(tmp_path / "actions-132.json")
+
+
+def test_a_corrupt_summary_is_reported_not_raised_raw(tmp_path):
+    path = write_session(tmp_path)
+    (tmp_path / "summary-132.json").write_text("{not json at all")
+    with pytest.raises(ActionsConfigError, match="not valid JSON"):
+        build_session(path)
+
+
+def test_a_summary_that_is_not_an_object_is_refused(tmp_path):
+    path = write_session(tmp_path)
+    (tmp_path / "summary-132.json").write_text('["complete"]')
+    with pytest.raises(ActionsConfigError, match="expected an object"):
+        build_session(path)
 
 
 def test_load_backfill_rejects_a_non_list(tmp_path):

--- a/tests/unit/test_build_actions_config.py
+++ b/tests/unit/test_build_actions_config.py
@@ -1,0 +1,134 @@
+"""Tests for the actions-config builder script."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from maine_bills.actions_config import ActionsConfigError
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "build_actions_config.py"
+
+
+@pytest.fixture(scope="module")
+def build_mod():
+    spec = importlib.util.spec_from_file_location("build_actions_config", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def artifact(directory: Path, session: int, n: int = 2, complete: bool = True, nested=False):
+    """Write one session's artifact pair, optionally in a per-artifact subdir."""
+    target = directory / f"actions-{session}" if nested else directory
+    target.mkdir(parents=True, exist_ok=True)
+    records = [
+        {
+            "session": session,
+            "ld_number": f"{i:04d}",
+            "paper": f"SP {i}",
+            "title": "An Act",
+            "flags": [],
+            "committee": "Judiciary",
+            "referred_date": None,
+            "final_disposition": None,
+            "final_disposition_date": None,
+            "governor_action": None,
+            "governor_action_date": None,
+            "chaptered_law": None,
+            "actions": [
+                {"date": "2025-01-15", "action": "Voted", "result": "OTP", "raw_date": "Jan 15"}
+            ],
+            "action_count": 1,
+            "source_url": "https://legislature.maine.gov/x",
+        }
+        for i in range(1, n + 1)
+    ]
+    (target / f"actions-{session}.json").write_text(json.dumps(records))
+    (target / f"summary-{session}.json").write_text(
+        json.dumps(
+            {"session": session, "records": n, "complete": complete, "aborted": not complete}
+        )
+    )
+
+
+def test_it_writes_one_parquet_per_session_laid_out_like_the_bills_config(build_mod, tmp_path):
+    src, out = tmp_path / "in", tmp_path / "out"
+    artifact(src, 131, n=3)
+    artifact(src, 132, n=2)
+
+    summary = build_mod.build(src, out)
+
+    assert summary["sessions_built"] == 2
+    assert summary["rows"] == 5
+    assert summary["actions"] == 5
+    for session, rows in ((131, 3), (132, 2)):
+        path = out / str(session) / "train-00000-of-00001.parquet"
+        assert path.exists()
+        assert len(pd.read_parquet(path)) == rows
+
+
+def test_the_parquet_round_trips_the_nested_actions(build_mod, tmp_path):
+    src, out = tmp_path / "in", tmp_path / "out"
+    artifact(src, 132, n=1)
+    build_mod.build(src, out)
+
+    frame = pd.read_parquet(out / "132" / "train-00000-of-00001.parquet")
+    actions = list(frame["actions"].iloc[0])
+    assert len(actions) == 1
+    assert actions[0]["action"] == "Voted"
+    assert actions[0]["date"] == "2025-01-15"
+
+
+def test_artifacts_are_found_in_per_artifact_subdirectories(build_mod, tmp_path):
+    """Downloading N artifacts from a run nests each one in its own directory."""
+    src, out = tmp_path / "in", tmp_path / "out"
+    artifact(src, 131, nested=True)
+    artifact(src, 132, nested=True)
+    assert build_mod.build(src, out)["sessions_built"] == 2
+
+
+def test_an_incomplete_session_stops_the_build_by_default(build_mod, tmp_path):
+    src, out = tmp_path / "in", tmp_path / "out"
+    artifact(src, 131)
+    artifact(src, 132, complete=False)
+    with pytest.raises(ActionsConfigError, match="not complete"):
+        build_mod.build(src, out)
+
+
+def test_no_strict_skips_the_bad_session_and_reports_it(build_mod, tmp_path):
+    src, out = tmp_path / "in", tmp_path / "out"
+    artifact(src, 131)
+    artifact(src, 132, complete=False)
+
+    summary = build_mod.build(src, out, strict=False)
+    assert summary["sessions_built"] == 1
+    assert summary["sessions_skipped"] == ["actions-132.json"]
+    assert not (out / "132").exists()
+
+
+def test_skipping_a_session_still_exits_non_zero(build_mod, tmp_path, monkeypatch):
+    """Otherwise --no-strict is a green build that quietly shipped a gap."""
+    src, out = tmp_path / "in", tmp_path / "out"
+    artifact(src, 131)
+    artifact(src, 132, complete=False)
+    code = build_mod.main(["--input", str(src), "--output", str(out), "--no-strict"])
+    assert code == 1
+    assert json.loads((out / "build-summary.json").read_text())["sessions_skipped"]
+
+
+def test_an_empty_input_directory_is_an_error_not_an_empty_config(build_mod, tmp_path):
+    src = tmp_path / "in"
+    src.mkdir()
+    with pytest.raises(ActionsConfigError, match="No actions"):
+        build_mod.build(src, tmp_path / "out")
+
+
+def test_main_returns_zero_and_writes_a_summary_on_a_clean_build(build_mod, tmp_path):
+    src, out = tmp_path / "in", tmp_path / "out"
+    artifact(src, 132, n=4)
+    assert build_mod.main(["--input", str(src), "--output", str(out)]) == 0
+    summary = json.loads((out / "build-summary.json").read_text())
+    assert summary["per_session"] == [{"session": 132, "rows": 4, "actions": 4}]

--- a/tests/unit/test_build_actions_config.py
+++ b/tests/unit/test_build_actions_config.py
@@ -166,3 +166,47 @@ def test_orphan_detection_finds_nested_artifacts_too(build_mod, tmp_path):
     (src / "actions-126" / "summary-126.json").write_text(json.dumps({"session": 126}))
     with pytest.raises(ActionsConfigError, match="126"):
         build_mod.build(src, out)
+
+
+def test_a_re_dispatched_session_supersedes_its_failed_attempt(build_mod, tmp_path):
+    """Session 126 failed in the first full backfill and was re-run, so
+    `actions-126` exists on two runs. The complete copy has to win, and the
+    failed one must not register as a gap."""
+    src, out = tmp_path / "in", tmp_path / "out"
+    failed_run, good_run = src / "run-1" / "actions-126", src / "run-2" / "actions-126"
+    failed_run.mkdir(parents=True)
+    (failed_run / "summary-126.json").write_text(
+        json.dumps({"session": 126, "complete": False, "aborted": True})
+    )
+    good_run.mkdir(parents=True)
+    artifact(good_run, 126, n=3)
+    # The good copy is written flat inside its own directory by `artifact`.
+
+    summary = build_mod.build(src, out)
+    assert summary["sessions_built"] == 1
+    assert summary["rows"] == 3
+    assert summary["sessions_skipped"] == []
+
+
+def test_the_complete_copy_wins_regardless_of_directory_order(build_mod, tmp_path):
+    """Even when the incomplete copy sorts last."""
+    src, out = tmp_path / "in", tmp_path / "out"
+    good, bad = src / "run-a", src / "run-z"
+    good.mkdir(parents=True)
+    bad.mkdir(parents=True)
+    artifact(good, 131, n=5)
+    artifact(bad, 131, n=1, complete=False)
+
+    summary = build_mod.build(src, out)
+    assert summary["per_session"] == [{"session": 131, "rows": 5, "actions": 5}]
+
+
+def test_a_session_failed_on_every_run_is_still_a_gap(build_mod, tmp_path):
+    src, out = tmp_path / "in", tmp_path / "out"
+    for run in ("run-1", "run-2"):
+        d = src / run
+        d.mkdir(parents=True)
+        (d / "summary-126.json").write_text(json.dumps({"session": 126, "complete": False}))
+    artifact(src / "run-1", 131)
+    with pytest.raises(ActionsConfigError, match="126"):
+        build_mod.build(src, out)

--- a/tests/unit/test_build_actions_config.py
+++ b/tests/unit/test_build_actions_config.py
@@ -201,6 +201,20 @@ def test_the_complete_copy_wins_regardless_of_directory_order(build_mod, tmp_pat
     assert summary["per_session"] == [{"session": 131, "rows": 5, "actions": 5}]
 
 
+def test_the_later_run_wins_when_both_copies_are_complete(build_mod, tmp_path):
+    """ "Later" has to mean numerically later. Lexicographic ordering puts
+    `run-9` after `run-10`, so the re-run would lose to the run it replaced --
+    invisible on GitHub's equal-width run ids, plain on a local run-1..run-12."""
+    src, out = tmp_path / "in", tmp_path / "out"
+    for run, rows in (("run-9", 5), ("run-10", 7)):
+        d = src / run
+        d.mkdir(parents=True)
+        artifact(d, 131, n=rows)
+
+    summary = build_mod.build(src, out)
+    assert summary["per_session"] == [{"session": 131, "rows": 7, "actions": 7}]
+
+
 def test_a_session_failed_on_every_run_is_still_a_gap(build_mod, tmp_path):
     src, out = tmp_path / "in", tmp_path / "out"
     for run in ("run-1", "run-2"):

--- a/tests/unit/test_build_actions_config.py
+++ b/tests/unit/test_build_actions_config.py
@@ -132,3 +132,37 @@ def test_main_returns_zero_and_writes_a_summary_on_a_clean_build(build_mod, tmp_
     assert build_mod.main(["--input", str(src), "--output", str(out)]) == 0
     summary = json.loads((out / "build-summary.json").read_text())
     assert summary["per_session"] == [{"session": 132, "rows": 4, "actions": 4}]
+
+
+def test_a_summary_with_no_records_is_caught_not_silently_skipped(build_mod, tmp_path):
+    """Session 126 of the first full backfill: it crashed during enumeration and
+    uploaded a summary with no actions file. Globbing for records alone cannot
+    see that, so the build would quietly produce one session fewer and report
+    success — the same silent gap the completeness check exists to prevent,
+    arriving by the one route that check cannot cover."""
+    src, out = tmp_path / "in", tmp_path / "out"
+    artifact(src, 131)
+    (src / "summary-126.json").write_text(
+        json.dumps({"session": 126, "complete": False, "aborted": True, "error": "HfHubHTTPError"})
+    )
+    with pytest.raises(ActionsConfigError, match="126"):
+        build_mod.build(src, out)
+
+
+def test_an_orphan_summary_is_reported_under_no_strict(build_mod, tmp_path):
+    src, out = tmp_path / "in", tmp_path / "out"
+    artifact(src, 131)
+    (src / "summary-126.json").write_text(json.dumps({"session": 126, "complete": False}))
+
+    summary = build_mod.build(src, out, strict=False)
+    assert summary["sessions_built"] == 1
+    assert "session-126" in summary["sessions_skipped"]
+
+
+def test_orphan_detection_finds_nested_artifacts_too(build_mod, tmp_path):
+    src, out = tmp_path / "in", tmp_path / "out"
+    artifact(src, 131, nested=True)
+    (src / "actions-126").mkdir(parents=True)
+    (src / "actions-126" / "summary-126.json").write_text(json.dumps({"session": 126}))
+    with pytest.raises(ActionsConfigError, match="126"):
+        build_mod.build(src, out)


### PR DESCRIPTION
Turns the twelve-session status backfill (#19) into a publishable dataset config. Builds parquet locally and stops — **publishing is not part of this PR** and stays behind the `huggingface-publish` gate.

> **Changed after review was requested** (commit `8b279644`, four Copilot findings). One is a **behaviour change worth knowing before you read**: `build_session` now *refuses* a complete-but-empty session rather than returning an empty frame. Details at the bottom.

## Why this is Tier-1

Two reasons, either one sufficient:

1. It defines a **published column layout**. Once a consumer joins against it, the column set and the nested struct are a compatibility surface.
2. It changes `.github/` — the `build-actions` job needs `actions: read` to download artifacts from other workflow runs.

## What the config is

One row per bill, joining to the bills config on `(session, ld_number)`, with the committee docket nested as a list.

| | |
|---|---|
| Bill-level | `session`, `ld_number`, `paper`, `title`, `flags`, `committee`, `referred_date`, `final_disposition`, `final_disposition_date`, `governor_action`, `governor_action_date`, `chaptered_law`, `source_url` |
| Docket | `actions` (list of `{date, action, result, raw_date}`), `action_count` |

**Nested rather than long format** because the bill-level fields belong to the bill, not to any single docket row. A long table repeats them on every row and invites copies to disagree. Exploding `actions` is one line; the reverse is a groupby and a reconstruction.

**`ld_number` is zero-padded**, matching the bills config. The join is one-to-many from this side — amendments in the bills table share their parent's LD, because a bill's status describes the bill, not each printed document.

**Nulls are never filled.** A bill with no committee referral has `committee = None`. That is distinguishable from a bill whose referral we failed to parse, because a page that does not parse is recorded as a failure and excluded, not written as an empty row.

## Build result

Run [30325716169](https://github.com/PhilipMathieu/maine-bills/actions/runs/30325716169) — 12 sessions, 1.5 MB.

| Session | Bills | Actions | | Session | Bills | Actions |
|---|---|---|---|---|---|---|
| 121 | 1,964 | 7,524 | | 127 | 1,703 | 6,431 |
| 122 | 2,120 | 7,859 | | 128 | 1,927 | 7,269 |
| 123 | 2,322 | 8,675 | | 129 | 2,174 | 8,239 |
| 124 | 1,832 | 7,364 | | 130 | 2,041 | 7,481 |
| 125 | 1,916 | 7,584 | | 131 | 2,291 | 8,440 |
| 126 | 1,865 | 7,528 | | 132 | 2,041 | 7,393 |
| | | | | **Total** | **24,196** | **91,787** |

Those totals were computed by the builder from the artifacts and match the backfill's own reported totals independently.

## What the builder refuses to do

The hazard this config exists to avoid is publishing a **partial session**, which is shape-identical to a complete session for a smaller legislature. Nothing in the data can tell them apart, so the checks all key on the summary the backfill writes beside the records:

- Summary missing → refuse. Every run writes one even when it crashes, so its absence means the artifact is not from a finished run.
- `complete: false` → refuse, quoting `aborted` / `failed` / `not_attempted` / `abort_reason`.
- Record count disagrees with the summary → refuse as truncated. Both files come from the same run.
- Either file unparseable → refuse with the filename, as an `ActionsConfigError` rather than a raw `JSONDecodeError`.
- **Complete but zero records → refuse.** Enumeration reads the LD set from the published parquet, so an empty session is not a small session; it is enumeration returning nothing and the run finishing anyway.
- A summary with **no records file anywhere** in the input → refuse. This is exactly what session 126's first attempt left behind when it died on a rate limit during enumeration. Globbing for records alone cannot see it, so the build would have quietly produced eleven sessions and reported success — the silent gap arriving through the one path the completeness check cannot see.
- A record missing a published column → refuse, rather than shipping a column of nulls when the backfill and this config drift apart.
- Duplicate `ld_number`, mixed sessions, or `action_count` disagreeing with `len(actions)` → refuse. A repeated join key silently multiplies rows in the bills table.

`--no-strict` downgrades the per-session refusals to skips and exits 1, so an operator can ship eleven sessions while the twelfth re-runs. It is off by default because that failure mode is quiet.

## Duplicate artifacts across runs

Session 126 exists in two runs — the failed original and the successful re-dispatch. `gh run download` errors on a filename collision rather than overwriting, so each run is downloaded into its own directory and `resolve_sessions` picks between copies: **a complete copy always beats an incomplete one**, which is what re-running a session means. Between two equally complete copies the numerically later run wins.

`orphan_summaries` is scoped across the whole input for the same reason — a failed attempt sitting beside its successful re-run is not a gap, it is the re-run working.

## Nested struct normalization

Parquet infers the struct from the data, so a single row whose actions happen to omit `result` would change the published schema for the entire file. Every action is rewritten with identical keys in a fixed order before the frame is built, and the empty frame is given the same pinned dtypes as a populated one.

## Tests

33 new, 554 passing, `ruff check` and `ruff format --check` clean on `src/`, `tests/`, and `scripts/`.

## Review notes

The thing worth your attention is **`COLUMNS` and `ACTION_FIELDS`** in `src/maine_bills/actions_config.py` — they are the compatibility surface, written out explicitly rather than derived from a dict so that adding a field to the backfill record cannot reorder or introduce a published column without this file changing too. If the column set or the nested field names are wrong, now is the cheap time to say so.

<details>
<summary>What changed after review was requested</summary>

Four Copilot findings, all valid. Two shared a root cause: `build_frame([])` was written as a supported case and nothing downstream could handle what it returned.

1. **An empty session crashed the builder.** `build_session` returned early on empty and the builder then read `frame["session"].iloc[0]` to name the output directory — `IndexError` before any parquet or summary was written. Rather than teach the builder to derive the session from the filename, `build_session` now refuses an empty session outright, for the reason given above. **This is the behaviour change**; `--no-strict` downgrades it to a skip like any other refusal.
2. **The empty frame had the wrong dtypes** — `object` everywhere, so an empty session written to parquet would not match the schema of any other session. Both construction paths now share one `_DTYPES` mapping.
3. **A truncated artifact raised `JSONDecodeError`**, which the CLI does not catch — a bare traceback instead of a named file, and `--no-strict` could not skip past it.
4. **"The later run wins" meant "sorts last as text."** `run-9` sorted after `run-10`. Invisible on GitHub's equal-width run ids, plain on a local `run-1..run-12`. Now ordered numerically.

Each fix is isolated by a test that goes red when only that fix is reverted, verified by mutating the source **in place** — the package is installed editable, so mutating a copy makes every mutation look survived.

</details>