### PR TITLE
[Tier-2] retry a HuggingFace rate limit during backfill enumeration

### DIFF
--- a/scripts/backfill_bill_status.py
+++ b/scripts/backfill_bill_status.py
@@ -92,11 +92,28 @@ RETRY_AFTER_ABORT = 120.0
 MAX_RETRY_PASS = 50
 
 # Enumeration is a single anonymous HuggingFace API call per session, made at
-# job start. Several sessions launching together on one runner IP can exhaust
-# the anonymous budget (500 requests per 300s), which killed session 126 of the
-# first full backfill four seconds in. The retry is generous because the window
-# is short and the alternative is losing the whole session.
+# job start. Session 126 of the first full backfill died four seconds in on
+# "429 ... 0/500 requests remaining in current 300s window", losing a healthy
+# session.
+#
+# Note what this comment used to claim: that our own sessions exhaust the
+# budget. They cannot -- max-parallel is 3 and enumeration is a handful of
+# requests, nowhere near 500 in 300s. The budget is per IP and shared with
+# whatever else that runner IP is doing, so the limit is someone else's and can
+# outlast our envelope. Worth being accurate about, because it means four
+# attempts is not obviously enough: when the server states no wait, the envelope
+# is 3 x 60s against a 300s window. Losing the session after that is the correct
+# outcome -- the alternative is sitting in a job that has a 120-minute timeout.
 ENUMERATION_ATTEMPTS = 4
+
+# Waits are floored so a "Retry-After: 0" cannot produce a tight retry loop,
+# capped because the anonymous window is 300s wide so nothing longer can be a
+# genuine wait for it, and defaulted when the server says nothing about timing.
+# A 429 that names no interval still has to back off; hammering is the one
+# failure mode here with an outside party.
+RATE_LIMIT_FLOOR = 1.0
+RATE_LIMIT_CAP = 300.0
+RATE_LIMIT_FALLBACK = 60.0
 
 
 class SiteRefusing(Exception):
@@ -154,16 +171,32 @@ def _hf_retry_after(error: Exception) -> float | None:
     nothing longer can be a genuine wait for it, and a silly value would stall
     a job that has a timeout to respect.
     """
+    response = getattr(error, "response", None)
     text = str(error)
-    if "429" not in text and "rate limit" not in text.lower():
+
+    # The status code when we have it, the message only as a fallback. Matching
+    # "429" as a substring reads it out of HuggingFace's own Request ID --
+    # "404 Client Error. (Request ID: Root=1-68f429ab-...) Entry Not Found"
+    # contains it -- so a plain Entry-Not-Found would have been retried three
+    # times at 60s each before surfacing. \b anchors it to a standalone number.
+    status = getattr(response, "status_code", None)
+    if status is not None:
+        if status != 429:
+            return None
+    elif not re.search(r"\b429\b", text) and "rate limit" not in text.lower():
         return None
 
-    response = getattr(error, "response", None)
     if getattr(response, "headers", None) and response.headers.get("Retry-After"):
-        return retry_after(response, default=60.0)
+        # Floored, not just capped. retry_after() clamps a negative value to
+        # 0.0, and "Retry-After: 0" is a legal thing for a server to send --
+        # which would put us in a tight loop of four requests against a host
+        # that has just said 429. The floor is the whole point of backing off.
+        return max(retry_after(response, default=RATE_LIMIT_FALLBACK), RATE_LIMIT_FLOOR)
 
     match = re.search(r"Retry after (\d+) second", text)
-    return min(float(match.group(1)), 300.0) if match else 60.0
+    if match:
+        return min(max(float(match.group(1)), RATE_LIMIT_FLOOR), RATE_LIMIT_CAP)
+    return RATE_LIMIT_FALLBACK
 
 
 def session_ld_numbers(
@@ -187,6 +220,9 @@ def session_ld_numbers(
     dodge a rate limit would trade a publish-gate guarantee for a retry loop.
     """
     report = _load_report_module()
+    # Zero or fewer would skip the loop entirely and fall through to the raise
+    # below, reporting "failed after 0 attempts" without ever having tried.
+    attempts = max(attempts, 1)
 
     for attempt in range(1, attempts + 1):
         try:
@@ -206,7 +242,12 @@ def session_ld_numbers(
             # document.
             return sorted({normalize_ld(ld) for ld in df["ld_number"].dropna().unique()})
 
-    raise RuntimeError(f"Session {session}: enumeration failed after {attempts} attempts")
+    # Unreachable: the final iteration either returns or re-raises the original
+    # error, which is better diagnostics than this would be. Kept so the
+    # function cannot fall off the end returning None if that ever changes.
+    raise RuntimeError(  # pragma: no cover
+        f"Session {session}: enumeration failed after {attempts} attempts"
+    )
 
 
 def retry_after(response, default: float) -> float:

--- a/scripts/backfill_bill_status.py
+++ b/scripts/backfill_bill_status.py
@@ -132,14 +132,36 @@ def _load_report_module():
 
 
 def _hf_retry_after(error: Exception) -> float | None:
-    """Seconds HuggingFace asked us to wait, if this is a rate limit.
+    """Seconds HuggingFace asked us to wait, or None if this is not a rate limit.
 
-    The 429 body carries "Retry after N seconds"; the header is not always
-    present on the exception, so the message is the reliable source.
+    None is the signal to re-raise immediately: a missing session or a bad URL
+    must surface on the first attempt rather than being retried four times.
+
+    Three sources, in descending order of authority:
+
+    1. The ``Retry-After`` header, when the exception carries a response.
+       ``huggingface_hub`` raises ``HfHubHTTPError``, a ``requests.HTTPError``
+       subclass that keeps the response on ``.response`` -- so the header
+       usually IS available, and it is what the server actually said. Parsed by
+       the same ``retry_after`` used for the legislature site.
+    2. The 429 body, which states "Retry after N seconds". This is the fallback
+       for an error that reaches us without a response object -- a wrapped or
+       re-raised exception, or a transport that does not attach one.
+    3. A flat 60s, so a rate limit that says nothing about timing still backs
+       off rather than hammering.
+
+    Both parsed forms are capped at 300s: the anonymous window is 300s wide, so
+    nothing longer can be a genuine wait for it, and a silly value would stall
+    a job that has a timeout to respect.
     """
     text = str(error)
     if "429" not in text and "rate limit" not in text.lower():
         return None
+
+    response = getattr(error, "response", None)
+    if getattr(response, "headers", None) and response.headers.get("Retry-After"):
+        return retry_after(response, default=60.0)
+
     match = re.search(r"Retry after (\d+) second", text)
     return min(float(match.group(1)), 300.0) if match else 60.0
 
@@ -147,7 +169,10 @@ def _hf_retry_after(error: Exception) -> float | None:
 def session_ld_numbers(
     parquet_source: str, session: int, attempts: int = ENUMERATION_ATTEMPTS
 ) -> list[str]:
-    """Every distinct LD number published for a session, in order.
+    """Every distinct LD number published for a session, ascending.
+
+    Sorted here rather than left in parquet order, so a caller can rely on the
+    ordering and a resumed run walks the session the same way as the first.
 
     Retries a HuggingFace rate limit. Enumeration is one anonymous API call per
     session at job start, and with several sessions launching at once on a

--- a/scripts/backfill_bill_status.py
+++ b/scripts/backfill_bill_status.py
@@ -30,6 +30,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import signal
 import sys
 import time
@@ -90,6 +91,13 @@ RETRY_AFTER_ABORT = 120.0
 # that failed in bulk, which is what the breakers are for.
 MAX_RETRY_PASS = 50
 
+# Enumeration is a single anonymous HuggingFace API call per session, made at
+# job start. Several sessions launching together on one runner IP can exhaust
+# the anonymous budget (500 requests per 300s), which killed session 126 of the
+# first full backfill four seconds in. The retry is generous because the window
+# is short and the alternative is losing the whole session.
+ENUMERATION_ATTEMPTS = 4
+
 
 class SiteRefusing(Exception):
     """The site asked us to go away for longer than this run should wait."""
@@ -106,8 +114,12 @@ class SiteRefusing(Exception):
 NOT_FOUND_MARKER = "Cannot find requested paper"
 
 
-def session_ld_numbers(parquet_source: str, session: int) -> list[str]:
-    """Every distinct LD number published for a session, in order."""
+def _load_report_module():
+    """The parquet loader from run_matching_report.py.
+
+    Separate from its caller so a test can substitute it without a network or a
+    real parquet file.
+    """
     import importlib.util
 
     report_path = Path(__file__).with_name("run_matching_report.py")
@@ -116,11 +128,60 @@ def session_ld_numbers(parquet_source: str, session: int) -> list[str]:
         raise ImportError(f"Cannot load the parquet loader from {report_path}")
     report = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(report)
+    return report
 
-    df = report.load_session_bills(parquet_source, session)
-    # Amendments share their parent bill's LD, so distinct LDs are what we want:
-    # the status page describes the bill, not each printed document.
-    return sorted({normalize_ld(ld) for ld in df["ld_number"].dropna().unique()})
+
+def _hf_retry_after(error: Exception) -> float | None:
+    """Seconds HuggingFace asked us to wait, if this is a rate limit.
+
+    The 429 body carries "Retry after N seconds"; the header is not always
+    present on the exception, so the message is the reliable source.
+    """
+    text = str(error)
+    if "429" not in text and "rate limit" not in text.lower():
+        return None
+    match = re.search(r"Retry after (\d+) second", text)
+    return min(float(match.group(1)), 300.0) if match else 60.0
+
+
+def session_ld_numbers(
+    parquet_source: str, session: int, attempts: int = ENUMERATION_ATTEMPTS
+) -> list[str]:
+    """Every distinct LD number published for a session, in order.
+
+    Retries a HuggingFace rate limit. Enumeration is one anonymous API call per
+    session at job start, and with several sessions launching at once on a
+    shared runner IP that is enough to exhaust the anonymous budget: session
+    126 of the first full backfill died four seconds in with "429 ... 0/500
+    requests remaining in current 300s window", losing an otherwise healthy
+    session's worth of work.
+
+    Deliberately not solved with a token. HF_TOKEN is scoped to the
+    `huggingface-publish` environment so it is only ever exposed to approved
+    publish runs (docs/GOVERNANCE.md); handing it to an ungated read job to
+    dodge a rate limit would trade a publish-gate guarantee for a retry loop.
+    """
+    report = _load_report_module()
+
+    for attempt in range(1, attempts + 1):
+        try:
+            df = report.load_session_bills(parquet_source, session)
+        except Exception as e:
+            wait = _hf_retry_after(e)
+            if wait is None or attempt == attempts:
+                raise
+            logger.warning(
+                f"Session {session}: enumeration rate-limited, waiting {wait:.0f}s "
+                f"(attempt {attempt}/{attempts})"
+            )
+            time.sleep(wait)
+        else:
+            # Amendments share their parent bill's LD, so distinct LDs are what
+            # we want: the status page describes the bill, not each printed
+            # document.
+            return sorted({normalize_ld(ld) for ld in df["ld_number"].dropna().unique()})
+
+    raise RuntimeError(f"Session {session}: enumeration failed after {attempts} attempts")
 
 
 def retry_after(response, default: float) -> float:

--- a/tests/unit/test_backfill_bill_status.py
+++ b/tests/unit/test_backfill_bill_status.py
@@ -57,9 +57,10 @@ def status_page(session=132, ld="1", paper="SP 29", rows=(("Jan 15, 2025", "Vote
 
 
 class FakeResponse:
-    def __init__(self, status_code=200, text=""):
+    def __init__(self, status_code=200, text="", headers=None):
         self.status_code = status_code
         self.text = text
+        self.headers = headers or {}
 
 
 class FakeSession:
@@ -962,6 +963,43 @@ HF_429 = (
 def test_a_huggingface_rate_limit_is_recognised_and_its_wait_honoured(backfill_mod):
     """Verbatim body from the session-126 failure."""
     assert backfill_mod._hf_retry_after(RuntimeError(HF_429)) == 61.0
+
+
+def rate_limited(headers=None):
+    """The session-126 error as huggingface_hub raises it: an HTTPError-alike
+    carrying the response, so .headers is reachable."""
+    error = RuntimeError(HF_429)
+    error.response = FakeResponse(status_code=429, headers=headers)
+    return error
+
+
+def test_the_retry_after_header_outranks_the_body(backfill_mod):
+    """huggingface_hub raises HfHubHTTPError, a requests.HTTPError subclass that
+    keeps the response on .response — so the header the server actually sent is
+    usually available, and it outranks prose parsed out of the body."""
+    assert backfill_mod._hf_retry_after(rate_limited({"Retry-After": "7"})) == 7.0
+
+
+def test_the_body_is_used_when_the_error_carries_no_header(backfill_mod):
+    """A wrapped or re-raised exception can reach us without one."""
+    assert backfill_mod._hf_retry_after(rate_limited()) == 61.0
+
+
+def test_a_junk_retry_after_header_falls_back_rather_than_crashing(backfill_mod):
+    """The HTTP-date form is legal and unparsed; a miss must not lose the retry."""
+    header = {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+    assert backfill_mod._hf_retry_after(rate_limited(header)) == 60.0
+
+
+def test_an_absurd_retry_after_header_is_capped(backfill_mod):
+    assert backfill_mod._hf_retry_after(rate_limited({"Retry-After": "99999"})) == 300.0
+
+
+def test_a_response_on_a_non_rate_limit_error_is_still_not_retried(backfill_mod):
+    """The header must not turn an unrelated failure into a retry."""
+    error = FileNotFoundError("No parquet files for session 999")
+    error.response = FakeResponse(status_code=429, headers={"Retry-After": "7"})
+    assert backfill_mod._hf_retry_after(error) is None
 
 
 def test_an_unrelated_error_is_not_treated_as_a_rate_limit(backfill_mod):

--- a/tests/unit/test_backfill_bill_status.py
+++ b/tests/unit/test_backfill_bill_status.py
@@ -996,9 +996,15 @@ def test_an_absurd_retry_after_header_is_capped(backfill_mod):
 
 
 def test_a_response_on_a_non_rate_limit_error_is_still_not_retried(backfill_mod):
-    """The header must not turn an unrelated failure into a retry."""
+    """The header must not turn an unrelated failure into a retry.
+
+    The status here used to be 429, which made the fixture incoherent once the
+    status code became authoritative: a response saying 429 IS a rate limit,
+    whatever the exception type wrapping it. A server that sends Retry-After
+    alongside a 404 is the case this is actually about.
+    """
     error = FileNotFoundError("No parquet files for session 999")
-    error.response = FakeResponse(status_code=429, headers={"Retry-After": "7"})
+    error.response = FakeResponse(status_code=404, headers={"Retry-After": "7"})
     assert backfill_mod._hf_retry_after(error) is None
 
 
@@ -1060,3 +1066,106 @@ def test_a_missing_session_is_not_retried(backfill_mod, monkeypatch):
     monkeypatch.setattr(backfill_mod, "_load_report_module", lambda: NoSuchSession)
     with pytest.raises(FileNotFoundError):
         backfill_mod.session_ld_numbers("hf://x", 999)
+
+
+# --- review of #23: the permissive direction, which was unpinned ---
+#
+# An independent review ran 22 mutations and five survived, all of them
+# LOOSENING something. The deletion mutations were all caught; nothing stopped
+# a constant or a predicate from drifting wider.
+
+
+def test_the_default_attempt_count_is_the_one_that_runs(backfill_mod, monkeypatch, sleeps):
+    """ENUMERATION_ATTEMPTS was pinned in neither direction: setting it to 3 or
+    to 99 left the whole suite green. 99 matters — at the 300s cap that is ~8
+    hours of sleeping inside a job with a 120-minute timeout."""
+    calls = {"n": 0}
+
+    class AlwaysLimited:
+        @staticmethod
+        def load_session_bills(_src, _session):
+            calls["n"] += 1
+            raise RuntimeError(HF_429)
+
+    monkeypatch.setattr(backfill_mod, "_load_report_module", lambda: AlwaysLimited)
+    with pytest.raises(RuntimeError, match="rate limit"):
+        backfill_mod.session_ld_numbers("hf://x", 126)
+
+    assert calls["n"] == backfill_mod.ENUMERATION_ATTEMPTS
+    assert backfill_mod.ENUMERATION_ATTEMPTS == 4
+    # The whole retry envelope has to fit inside the job timeout.
+    worst_case = (backfill_mod.ENUMERATION_ATTEMPTS - 1) * backfill_mod.RATE_LIMIT_CAP
+    assert worst_case < 120 * 60
+
+
+def test_a_rate_limit_that_names_no_interval_still_backs_off(backfill_mod):
+    """The documented third source. Mutating the fallback to 0.0 survived every
+    test — and this is not hypothetical: hf_raise_for_status can produce
+    "429 Client Error: None for url: ..." with neither a header nor the HF body
+    prose, which lands exactly here."""
+    assert backfill_mod._hf_retry_after(RuntimeError("429 Client Error: None for url: x")) >= 1.0
+    assert backfill_mod._hf_retry_after(RuntimeError("429 Client Error: None for url: x")) == 60.0
+
+
+def test_a_zero_retry_after_header_does_not_become_a_tight_loop(backfill_mod):
+    """retry_after clamps negatives to 0.0 and "Retry-After: 0" is legal, so the
+    header branch could return 0.0 — four requests in a tight loop against a
+    host that has just said 429. Backing off is the entire point."""
+    for raw in ("0", "-5", "0.0"):
+        assert backfill_mod._hf_retry_after(rate_limited({"Retry-After": raw})) >= 1.0
+
+
+def test_a_body_stated_wait_is_floored_too(backfill_mod):
+    error = RuntimeError("429 rate limit. Retry after 0 seconds")
+    assert backfill_mod._hf_retry_after(error) >= 1.0
+
+
+def test_a_request_id_containing_429_is_not_a_rate_limit(backfill_mod):
+    """HuggingFace embeds a Request ID in every error, and hex digits spell 429
+    often enough to matter. Matching it as a substring meant a plain
+    Entry-Not-Found was retried three times at 60s each before surfacing."""
+    error = RuntimeError(
+        "404 Client Error. (Request ID: Root=1-68f429ab-3c2f) Entry Not Found "
+        "for url: https://huggingface.co/api/datasets/pem207/maine-bills"
+    )
+    assert backfill_mod._hf_retry_after(error) is None
+
+
+def test_the_status_code_outranks_the_message(backfill_mod):
+    """When the response is there, the code is authoritative — the message is
+    prose and can say anything."""
+    not_limited = RuntimeError("something about a rate limit, but a 500")
+    not_limited.response = FakeResponse(status_code=500, headers={"Retry-After": "7"})
+    assert backfill_mod._hf_retry_after(not_limited) is None
+
+    limited = RuntimeError("no useful words here")
+    limited.response = FakeResponse(status_code=429, headers={"Retry-After": "7"})
+    assert backfill_mod._hf_retry_after(limited) == 7.0
+
+
+def test_an_ordinary_error_is_not_retried_however_it_is_worded(backfill_mod):
+    """The negative side had exactly one bland fixture behind it, so widening
+    the predicate went undetected."""
+    for message in (
+        "No parquet files for session 999",
+        "Connection reset by peer",
+        "500 Server Error: Internal Server Error for url: x",
+        "404 Client Error. Entry Not Found",
+        "Error: something went wrong",
+    ):
+        assert backfill_mod._hf_retry_after(RuntimeError(message)) is None, message
+
+
+def test_a_nonpositive_attempt_count_still_tries_once(backfill_mod, monkeypatch):
+    """attempts=0 skipped the loop and reported "failed after 0 attempts"
+    without ever calling the loader."""
+
+    class Fine:
+        @staticmethod
+        def load_session_bills(_src, _session):
+            import pandas as pd
+
+            return pd.DataFrame({"ld_number": ["1"]})
+
+    monkeypatch.setattr(backfill_mod, "_load_report_module", lambda: Fine)
+    assert backfill_mod.session_ld_numbers("hf://x", 126, attempts=0) == ["0001"]

--- a/tests/unit/test_backfill_bill_status.py
+++ b/tests/unit/test_backfill_bill_status.py
@@ -946,3 +946,79 @@ def test_the_retry_pass_records_a_bill_that_turns_out_to_be_missing(
     assert summary["failed"] == 0
     assert summary["no_status_page"] == 1
     assert json.loads((tmp_path / "a-missing.json").read_text()) == ["0002"]
+
+
+# --- enumeration rate limit, from the first full backfill ---
+
+HF_429 = (
+    "(Request ID: Root=1-6a67de23)\n\n"
+    "429 Too Many Requests: you have reached your 'api' rate limit.\n"
+    "Retry after 61 seconds (0/500 requests remaining in current 300s window).\n"
+    "Url: https://huggingface.co/api/datasets/pem207/maine-bills.\n"
+    "We had to rate limit your IP (52.154.130.210)."
+)
+
+
+def test_a_huggingface_rate_limit_is_recognised_and_its_wait_honoured(backfill_mod):
+    """Verbatim body from the session-126 failure."""
+    assert backfill_mod._hf_retry_after(RuntimeError(HF_429)) == 61.0
+
+
+def test_an_unrelated_error_is_not_treated_as_a_rate_limit(backfill_mod):
+    """Only a rate limit should be retried; a missing session must surface."""
+    assert (
+        backfill_mod._hf_retry_after(FileNotFoundError("No parquet files for session 999")) is None
+    )
+
+
+def test_an_absurd_hf_wait_is_capped(backfill_mod):
+    assert (
+        backfill_mod._hf_retry_after(RuntimeError("429 rate limit. Retry after 99999 seconds"))
+        == 300.0
+    )
+
+
+def test_a_rate_limited_enumeration_is_retried_not_lost(backfill_mod, monkeypatch, sleeps):
+    """Session 126 of the first full backfill died four seconds in on this,
+    losing a healthy session. Three sessions start at once on one runner IP and
+    the anonymous HF budget is 500 requests per 300s."""
+    calls = {"n": 0}
+
+    class FakeReport:
+        @staticmethod
+        def load_session_bills(_src, _session):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise RuntimeError(HF_429)
+            import pandas as pd
+
+            return pd.DataFrame({"ld_number": ["1", "2", "2"]})
+
+    monkeypatch.setattr(backfill_mod, "_load_report_module", lambda: FakeReport)
+    assert backfill_mod.session_ld_numbers("hf://x", 126) == ["0001", "0002"]
+    assert calls["n"] == 3
+    assert sleeps == [61.0, 61.0]
+
+
+def test_a_persistent_rate_limit_eventually_surfaces(backfill_mod, monkeypatch):
+    """It must not retry forever — the job has a timeout and a summary to write."""
+
+    class AlwaysLimited:
+        @staticmethod
+        def load_session_bills(_src, _session):
+            raise RuntimeError(HF_429)
+
+    monkeypatch.setattr(backfill_mod, "_load_report_module", lambda: AlwaysLimited)
+    with pytest.raises(RuntimeError, match="rate limit"):
+        backfill_mod.session_ld_numbers("hf://x", 126, attempts=2)
+
+
+def test_a_missing_session_is_not_retried(backfill_mod, monkeypatch):
+    class NoSuchSession:
+        @staticmethod
+        def load_session_bills(_src, _session):
+            raise FileNotFoundError("No parquet files for session 999")
+
+    monkeypatch.setattr(backfill_mod, "_load_report_module", lambda: NoSuchSession)
+    with pytest.raises(FileNotFoundError):
+        backfill_mod.session_ld_numbers("hf://x", 999)


### PR DESCRIPTION
Fixes the failure that killed session 126 in the first full backfill.

> **Reviewed and revised twice.** Copilot found the PR body claimed header handling the code didn't do. The independent Tier-2 review then returned **APPROVE** with six findings, two of which were real defects — see *What review changed* at the bottom. Rebased onto `dc8f35b7`.

## What happened

`backfill_bill_status.py` enumerates a session's LD numbers by reading the published parquet from HuggingFace. The anonymous API allows 500 requests per 300-second window, shared **per IP**. Session 126's enumeration hit a 429 and the script died four seconds in, before writing a single record — leaving behind a summary with no records file, which is the orphan case #22's builder now catches.

The session had to be re-dispatched by hand.

## The fix

`session_ld_numbers` retries enumeration up to `ENUMERATION_ATTEMPTS = 4` times. The wait comes from three sources in descending order of authority:

1. **The `Retry-After` header**, when the exception carries a response. `huggingface_hub` raises `HfHubHTTPError`, which keeps the response on `.response`.
2. **The 429 body**, which states `Retry after N seconds` — the fallback for an error that reaches us wrapped or re-raised.
3. **A flat 60s**, so a rate limit that names no interval still backs off.

All three are **floored at 1s and capped at 300s**. The cap because the anonymous window is 300s wide, so nothing longer can be a genuine wait for it. The floor because `Retry-After: 0` is legal and would otherwise produce four requests in a tight loop against a host that just said 429.

Enumeration is a handful of requests at the start of a run that takes hours, so a retry here is cheap and the alternative is discarding the whole session.

## What this deliberately does not do

**It does not use `HF_TOKEN`.** An authenticated read would raise the rate limit and make this a non-problem, but the token is scoped to the `huggingface-publish` environment precisely so it is only exposed to approved publish runs. The reviewer verified this holds mechanically: `HF_TOKEN` appears only in jobs declaring `environment: huggingface-publish`, so giving the ungated `backfill-status` job access would mean either putting a required-reviewer gate on every backfill run, or duplicating the secret at repo scope — which is itself Tier 1. Avoiding it is what keeps this PR Tier 2.

**It does not raise the request rate.** 1 req/sec against legislature.maine.gov and `max-parallel: 3` are unchanged.

## Tier decision

**Tier 2**, confirmed by the reviewer: the diff is exactly `scripts/backfill_bill_status.py` and its tests, with zero lines against `pyproject.toml`, `uv.lock`, `.github/`, or `src/`. Only new import is stdlib `re`. Nothing uploads.

## Risk

Scripts-only, read path, no publish and no persisted state. Worst realistic regression is added dead time in a CI job — measured worst case 900s against a 120-minute timeout, and a test now asserts the whole retry envelope fits inside it. No interaction with the circuit breakers: enumeration completes before `backfill()` starts. Resumability is unaffected, and on final failure the summary now carries the original `HfHubHTTPError` text rather than a synthesised `RuntimeError`, which is better diagnostics than before.

## Checks

- 573 passing; `ruff check` / `ruff format --check` clean on `scripts/` and `tests/`.
- 19 tests on this path.
- **Mutation: 11 of 11 killed**, including all five the reviewer found surviving. Sanity check: `RETRY_STATUSES` emptied → 7 failures. Mutated in place with `atexit` and signal handlers, after a timeout in an earlier run killed a harness before its `finally` could restore the source.

## Rollback

Revert the commits. Nothing stateful; no artifact or dataset format depends on this.

<details>
<summary>What review changed</summary>

Two real defects, both about behaviour toward an outside party:

**1. `Retry-After: 0` produced a tight retry loop.** `retry_after()` clamps negatives to `0.0`, and the truthiness guard passes for the string `"0"` — so the header branch returned `0.0`, the loop slept nothing and immediately re-requested. Four requests in a row at a host that had just said 429. Waits are floored now, not only capped.

**2. The rate-limit predicate matched `429` as a substring**, and HuggingFace embeds a Request ID in every error message:

```
404 Client Error. (Request ID: Root=1-68f429ab-3c2f) Entry Not Found
```

contains it. A plain Entry-Not-Found was therefore retried three times at 60s each before surfacing. The status code is authoritative now when the response carries one; the message fallback anchors on `\b429\b`.

Four test-strength and accuracy findings:

**3. `ENUMERATION_ATTEMPTS` was pinned in neither direction** — setting it to 3 *or* to 99 left the suite green. 99 is the one that matters: at the 300s cap that is ~8 hours of sleeping inside a job with a 120-minute timeout. This PR body also claimed the tests covered "exhaustion after four attempts". They did not — the only exhaustion test passes `attempts=2` explicitly. That is the same class of overclaim as the header one, in the same body.

**4. The documented 60s fallback was untested** and mutating it to `0.0` survived. Not hypothetical: `hf_raise_for_status` can produce `429 Client Error: None for url: ...` with neither a header nor the body prose.

**5. The comment above `ENUMERATION_ATTEMPTS` claimed our own sessions exhaust the budget.** They cannot — `max-parallel: 3` and a handful of requests is nowhere near 500 in 300s. The budget is per IP and shared with whatever else that runner is doing, so the limit is someone else's and can outlast our envelope. The commit message was careful about this; the comment a future reader would actually find was not.

**6. `attempts=0`** skipped the loop and reported "failed after 0 attempts" without ever calling the loader.

One existing test had to change rather than just be added to: `test_a_response_on_a_non_rate_limit_error_is_still_not_retried` built its fixture with `status_code=429`, which became incoherent once the status code was authoritative — a response saying 429 *is* a rate limit whatever exception wraps it. Its intent is preserved with a 404.

Also worth recording from the review: the retry only works because `HfFileSystem` overrides both `glob` and `find`. `HfHubHTTPError` subclasses `OSError`, and `fsspec`'s generic `walk` would have swallowed it into an empty glob and a `FileNotFoundError`, defeating the retry entirely. The premise holds, but it holds by accident of two overrides.

</details>