### PR TITLE
[Tier-2] two roster surname forms the sweep dropped (closes #20)

### DIFF
--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -111,31 +111,69 @@ _ROSTER_SURNAME = re.compile(r"[A-Z]{2}")
 #     CORNELL du HOUX            Representatives: CORNELL du HOUX of Brunswick
 #     SANBORN, H.                Senators: SANBORN, H. of Cumberland
 #
-# The particle arm is a shape rule -- two or three lowercase letters flanked on
-# both sides by capitalised words -- rather than a list of known particles,
-# because a list only ever covers the surnames already seen. Requiring every
-# word of a surname to be capitalised was the same mistake this file already
-# argues against for LOCALITIES, where "Isle au Haut" has a lowercase particle
-# -- and then made for names.
+# Requiring every word of a surname to be capitalised was the same mistake this
+# file already argues against for LOCALITIES, where "Isle au Haut" has a
+# lowercase particle -- and then made for names.
 #
-# "of" is excluded, and that exclusion is load-bearing. It is the one lowercase
-# token in this grammar with structural meaning, and without the lookahead the
-# name arm eats the separator whenever a second one follows:
+# The particle is an ALLOWLIST, and the first attempt at this got it wrong. It
+# used a shape rule -- "two or three lowercase letters" -- reasoning that a list
+# only ever covers the surnames already seen. That reasoning does not survive
+# contact with the vocabulary: [a-z]{2,3} is a superset of the English
+# connectives, so the rule had no discriminating power at all. Review ran these
+# through the extractor and every one became a sponsor:
+#
+#     MDOT and DHHS of Augusta      ->  "MDOT and DHHS"
+#     WAYS and MEANS of Funding     ->  "WAYS and MEANS"
+#     TAX on SALE of Goods          ->  "TAX on SALE"
+#     ONE per CENT of Revenue       ->  "ONE per CENT"
+#
+# "MDOT ... of Augusta" is the exact string the locality boundary above exists
+# to reject; a conjunction handed it straight back.
+#
+# The asymmetry that makes a list right here: surnames are open, but naming
+# PARTICLES are a closed class -- a few dozen across the European traditions,
+# and unchanged for centuries. A new legislator with a particle surname will use
+# one of these; a new legislator will not invent a particle.
+#
+# "of" is absent for a second, structural reason. It is the one lowercase token
+# in this grammar that means something, and when it was admitted the name arm
+# ate the separator whenever a second one followed:
 #
 #     BAILEY of York of Cumberland   ->  name "BAILEY of York", locality "Cumberland"
 #
-# Caught by test_the_particle_arm_does_not_swallow_the_locality_separator, which
-# was written to assert this could not happen and found that it did.
+# Caught by a test written to assert this could not happen, which found that it did.
 #
 # The trailing ", H." is how Maine distinguishes two sitting members who share a
 # surname. It is part of the name, not a cell boundary, so the cell splitter
 # has to keep it attached -- see _ROSTER_CELL_SPLIT.
 _ROSTER_WORD = r"[A-Z][A-Za-z'\-]*"
-_ROSTER_PARTICLE = r"(?!of\b)[a-z]{2,3}"
+_ROSTER_PARTICLES = (
+    "du",
+    "de",
+    "del",
+    "della",
+    "den",
+    "der",
+    "di",
+    "da",
+    "das",
+    "dos",
+    "la",
+    "le",
+    "van",
+    "von",
+    "ten",
+    "ter",
+    "af",
+    "av",
+    "bin",
+    "al",
+)
+_ROSTER_PARTICLE = "|".join(sorted(_ROSTER_PARTICLES, key=len, reverse=True))
 
 _ROSTER_ENTRY = re.compile(
     r"^(?:(?P<title>Senator|Representative|President|Speaker)\s+)?"
-    rf"(?P<name>{_ROSTER_WORD}(?:\s+(?:{_ROSTER_PARTICLE}\s+)?{_ROSTER_WORD})?"
+    rf"(?P<name>{_ROSTER_WORD}(?:\s+(?:(?:{_ROSTER_PARTICLE})\s+)?{_ROSTER_WORD})?"
     r"(?:,\s*[A-Z]\.)?)"
     r"\s+of\s+(?:"
     r"the\s+(?:(?:St|Mt|Ft)\.\s+)?[A-Z][\w'\-]*(?:\s+[\w'\-]+){0,5}"
@@ -143,10 +181,20 @@ _ROSTER_ENTRY = re.compile(
     r")\s*(?:\.|$)"
 )
 
-# The longest name _ROSTER_ENTRY can produce is "CORNELL du HOUX" -- three
-# whitespace-separated tokens. is_valid_name's default ceiling of two is right
-# for the title-adjoining patterns, which have no particle arm.
-_ROSTER_MAX_NAME_WORDS = 3
+# The longest name _ROSTER_ENTRY can produce is "CORNELL du HOUX, J." -- four
+# whitespace-separated tokens: two capitalised words, a particle, and a trailing
+# disambiguating initial. is_valid_name's default ceiling of two is right for
+# the title-adjoining patterns, which have neither a particle arm nor an initial.
+#
+# This said three, and was wrong rather than merely stale: the regex could
+# already produce four, so a particle surname carrying an initial was matched by
+# the pattern and then thrown away by the cap. Silently, and without ending the
+# run -- a name rejected on a clean cell is skipped, not cascaded -- so it would
+# have cost exactly one sponsor with nothing to show for it.
+#
+# Coupled to the pattern by test_the_arity_cap_matches_what_the_pattern_can_emit
+# rather than by this comment, which is what let the two drift apart.
+_ROSTER_MAX_NAME_WORDS = 4
 
 # Cells are comma-delimited, EXCEPT for the comma inside "SANBORN, H.".
 #
@@ -610,7 +658,14 @@ class TextExtractor:
             # SENATE, LEGISLATURE, UNIVERSITY and NATION were all reachable as
             # "sponsors" while the list that names them looked like it was doing
             # the work.
-            name_words = {word.casefold() for word in name.split()}
+            #
+            # Punctuation is stripped before the comparison, because a
+            # denylisted word carrying any is a DIFFERENT string and slips
+            # through: once the roster path started keeping the trailing
+            # disambiguator, "PART, A. of Chapter 12" split to {"part,", "a."}
+            # and "part," is not "part". That handed back the exact clause class
+            # the locality boundary above was built to reject.
+            name_words = {word.casefold().strip(".,'-") for word in name.split()}
             return not name_words.intersection(_TITLE_WORDS_FOLDED)
 
         # Pattern 1: "Presented by Senator/Representative/President/Speaker NAME [of DISTRICT]"

--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -102,14 +102,63 @@ _ROSTER_SURNAME = re.compile(r"[A-Z]{2}")
 # ". The" satisfies it -- so "BAILEY of York. The department shall report"
 # matches as ONE complete cell, the run never stops, and every cell behind the
 # prose is harvested. Caught by test_the_prefix_branch_stops_the_run.
+#
+# The name itself is one or two capitalised words, optionally joined by a short
+# lowercase PARTICLE and optionally carrying a trailing disambiguating initial:
+#
+#     SANBORN                    BAILEY of York
+#     TALBOT ROSS                Speaker TALBOT ROSS of Portland
+#     CORNELL du HOUX            Representatives: CORNELL du HOUX of Brunswick
+#     SANBORN, H.                Senators: SANBORN, H. of Cumberland
+#
+# The particle arm is a shape rule -- two or three lowercase letters flanked on
+# both sides by capitalised words -- rather than a list of known particles,
+# because a list only ever covers the surnames already seen. Requiring every
+# word of a surname to be capitalised was the same mistake this file already
+# argues against for LOCALITIES, where "Isle au Haut" has a lowercase particle
+# -- and then made for names.
+#
+# "of" is excluded, and that exclusion is load-bearing. It is the one lowercase
+# token in this grammar with structural meaning, and without the lookahead the
+# name arm eats the separator whenever a second one follows:
+#
+#     BAILEY of York of Cumberland   ->  name "BAILEY of York", locality "Cumberland"
+#
+# Caught by test_the_particle_arm_does_not_swallow_the_locality_separator, which
+# was written to assert this could not happen and found that it did.
+#
+# The trailing ", H." is how Maine distinguishes two sitting members who share a
+# surname. It is part of the name, not a cell boundary, so the cell splitter
+# has to keep it attached -- see _ROSTER_CELL_SPLIT.
+_ROSTER_WORD = r"[A-Z][A-Za-z'\-]*"
+_ROSTER_PARTICLE = r"(?!of\b)[a-z]{2,3}"
+
 _ROSTER_ENTRY = re.compile(
     r"^(?:(?P<title>Senator|Representative|President|Speaker)\s+)?"
-    r"(?P<name>[A-Z][A-Za-z'\-]*(?:\s+[A-Z][A-Za-z'\-]*)?)"
+    rf"(?P<name>{_ROSTER_WORD}(?:\s+(?:{_ROSTER_PARTICLE}\s+)?{_ROSTER_WORD})?"
+    r"(?:,\s*[A-Z]\.)?)"
     r"\s+of\s+(?:"
     r"the\s+(?:(?:St|Mt|Ft)\.\s+)?[A-Z][\w'\-]*(?:\s+[\w'\-]+){0,5}"
     r"|(?:(?:St|Mt|Ft)\.\s+)?[A-Z][\w'\-]*(?:\s+[\w'\-]+){0,3}"
     r")\s*(?:\.|$)"
 )
+
+# The longest name _ROSTER_ENTRY can produce is "CORNELL du HOUX" -- three
+# whitespace-separated tokens. is_valid_name's default ceiling of two is right
+# for the title-adjoining patterns, which have no particle arm.
+_ROSTER_MAX_NAME_WORDS = 3
+
+# Cells are comma-delimited, EXCEPT for the comma inside "SANBORN, H.".
+#
+# Splitting naively on every comma made that cell into "SANBORN" -- no locality,
+# so not an entry at all -- which ended the run and took the rest of the segment
+# with it. On session 129 HP0006 that is both names; the cascade is the real
+# cost, not the one entry.
+#
+# The lookahead is deliberately narrow: a single capital letter, a period, then
+# " of ". A locality cannot begin that way, because a locality only ever appears
+# after " of " itself. Anything else after a comma is a new cell.
+_ROSTER_CELL_SPLIT = re.compile(r",(?!\s*[A-Z]\.\s+of\s)")
 
 
 # Words on the general title_words denylist that ARE real Maine surnames, and
@@ -133,7 +182,7 @@ def _roster_name_ok(name: str, is_valid_name) -> bool:
         return False
     if name.casefold() in _ROSTER_NAME_ALLOW:
         return True
-    return is_valid_name(name)
+    return is_valid_name(name, max_words=_ROSTER_MAX_NAME_WORDS)
 
 
 def _roster_names(segment: str, is_valid_name):
@@ -159,7 +208,7 @@ def _roster_names(segment: str, is_valid_name):
     stop exists to prevent. Zero occurrences in 271 real bills, but the
     docstring above claimed prose is never read, and it has to be true.
     """
-    for cell in segment.split(","):
+    for cell in _ROSTER_CELL_SPLIT.split(segment):
         cell = cell.strip()
         match = _ROSTER_ENTRY.match(cell)
         if not match:
@@ -540,12 +589,19 @@ class TextExtractor:
         _TITLE_WORDS_FOLDED = {word.casefold() for word in title_words}
 
         # Helper function to validate names
-        def is_valid_name(name: str) -> bool:
-            """Check if extracted text is a valid legislator name."""
+        def is_valid_name(name: str, max_words: int = 2) -> bool:
+            """Check if extracted text is a valid legislator name.
+
+            ``max_words`` is 2 for the title-adjoining patterns, whose name
+            group cannot produce more. The roster path raises it to 3 because
+            its name group admits a lowercase particle -- "CORNELL du HOUX" --
+            and the arity cap would otherwise reject a name the pattern was
+            widened specifically to accept.
+            """
             # Deduplication is handled once, after collection, keyed on
             # (name, chamber) — checking names here would reject a second
             # legislator who shares a surname but sits in the other chamber.
-            if not name or len(name.split()) > 2:
+            if not name or len(name.split()) > max_words:
                 return False
             # Compared case-INSENSITIVELY. title_words is written in Title Case
             # and rosters print surnames in capitals, so a case-sensitive

--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -641,10 +641,15 @@ class TextExtractor:
             """Check if extracted text is a valid legislator name.
 
             ``max_words`` is 2 for the title-adjoining patterns, whose name
-            group cannot produce more. The roster path raises it to 3 because
-            its name group admits a lowercase particle -- "CORNELL du HOUX" --
-            and the arity cap would otherwise reject a name the pattern was
-            widened specifically to accept.
+            group cannot produce more. The roster path raises it to
+            _ROSTER_MAX_NAME_WORDS, because its name group admits a lowercase
+            particle and a trailing initial -- "CORNELL du HOUX, J." -- and the
+            cap would otherwise reject names the pattern was widened
+            specifically to accept.
+
+            Named rather than repeated as a literal: this docstring said "3"
+            after the constant had been corrected to 4, which is the same
+            comment-drifts-from-code failure the constant itself was fixed for.
             """
             # Deduplication is handled once, after collection, keyed on
             # (name, chamber) — checking names here would reject a second

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -666,3 +666,120 @@ def test_an_individual_title_inside_a_roster_keeps_its_own_chamber():
     assert by_name["BAILEY"] == "Senate"
     assert by_name["FECTEAU"] == "House"
     assert by_name["CURRY"] == "Senate"
+
+
+# --- issue #20: two real surname forms the sweep dropped ---
+#
+# Both were found by an independent review of #16 that ran the extractor over
+# 296 real bills via getPDF.asp, and both were deferred from that PR because
+# neither fix is a one-liner. Both cascade: the failing cell ends the run, so
+# every cosponsor behind it is lost too, which is the actual cost.
+
+
+def test_a_same_surname_disambiguator_is_part_of_the_name_not_a_cell_boundary():
+    """Session 129 HP0006, real text. Maine distinguishes two sitting members
+    who share a surname with a trailing initial. Splitting on every comma made
+    the first cell just "SANBORN" — no locality, so not an entry at all — which
+    ended the run and took VITELLI with it."""
+    text = (
+        "Cosponsored by Senators: SANBORN, H. of Cumberland, VITELLI of Sagadahoc.\n"
+        "Be it enacted:\n"
+    )
+    assert names(text) == ["SANBORN, H.", "VITELLI"]
+
+
+def test_the_disambiguator_is_kept_because_it_is_what_identifies_the_member():
+    """Dropping it back to "SANBORN" would merge two different legislators, and
+    the extracted string is supposed to be what the document says."""
+    text = "Cosponsored by Senators: SANBORN, H. of Cumberland.\nBe it enacted:\n"
+    assert names(text) == ["SANBORN, H."]
+
+
+def test_both_members_of_a_shared_surname_survive_as_separate_sponsors():
+    text = (
+        "Cosponsored by Senators: SANBORN, H. of Cumberland, "
+        "SANBORN, L. of Cumberland, VITELLI of Sagadahoc.\nBe it enacted:\n"
+    )
+    assert names(text) == ["SANBORN, H.", "SANBORN, L.", "VITELLI"]
+
+
+def test_a_surname_with_a_lowercase_particle_is_a_name():
+    """Session 125 HP0018, real text. The name group required every word
+    capitalised and allowed at most two, so "CORNELL du HOUX" failed — and it
+    is the FIRST cell, so all seven cosponsors were lost."""
+    text = (
+        "Cosponsored by Representatives: CORNELL du HOUX of Brunswick, "
+        "BEAULIEU of Auburn, BOLAND of Sanford, CAIN of Orono, CHASE of China, "
+        "DILL of Old Town, HUNT of Buxton.\nBe it enacted:\n"
+    )
+    assert names(text) == [
+        "CORNELL du HOUX",
+        "BEAULIEU",
+        "BOLAND",
+        "CAIN",
+        "CHASE",
+        "DILL",
+        "HUNT",
+    ]
+
+
+def test_the_particle_rule_is_the_one_this_file_already_argues_for_localities():
+    """text_extractor.py argues explicitly that localities must not require
+    every word capitalised, because "Isle au Haut" has a lowercase particle —
+    and then applied exactly that rule to surnames."""
+    text = (
+        "Cosponsored by Representatives: CORNELL du HOUX of Isle au Haut, "
+        "CAIN of Orono.\nBe it enacted:\n"
+    )
+    assert names(text) == ["CORNELL du HOUX", "CAIN"]
+
+
+# --- the widened patterns must not widen what they accept as a sponsor ---
+
+
+def test_the_particle_arm_does_not_swallow_the_locality_separator():
+    """A general "capital word, lowercase word, capital word" name could in
+    principle consume the " of " that bounds the locality. It cannot, because
+    the locality needs an " of " of its own."""
+    text = "Cosponsored by Senators: BAILEY of York of Cumberland.\nBe it enacted:\n"
+    assert names(text) == ["BAILEY"]
+
+
+def test_the_particle_arm_does_not_re_open_the_clause_class():
+    """The cases the locality boundary was added to reject must stay rejected
+    now that the name may carry a lowercase middle word."""
+    for clause in (
+        "MDOT of Augusta shall study the matter.",
+        "PART A of Chapter 12 takes effect on July 1.",
+        "MRSA of Title 5 is amended to read as follows.",
+    ):
+        text = f"Cosponsored by Senators: BAILEY of York, {clause}\n"
+        assert names(text) == ["BAILEY"], clause
+
+
+def test_a_denylisted_noun_is_still_dropped_when_it_carries_a_particle():
+    """Widening the arity ceiling to 3 must not let a denylisted word through
+    on a longer name."""
+    text = (
+        "Cosponsored by Senators: BAILEY of York, BOARD of the City of Portland, "
+        "CURRY of Waldo.\nBe it enacted:\n"
+    )
+    assert "BOARD" not in " ".join(names(text))
+    assert names(text) == ["BAILEY", "CURRY"]
+
+
+def test_the_disambiguator_lookahead_does_not_glue_ordinary_cells_together():
+    """Only "<single capital>. of " is an internal comma. Everything else after
+    a comma opens a new cell, including a name that merely starts with one."""
+    text = (
+        "Cosponsored by Senators: BAILEY of York, CURRY of Waldo, "
+        "GROHOSKI of Hancock.\nBe it enacted:\n"
+    )
+    assert names(text) == ["BAILEY", "CURRY", "GROHOSKI"]
+
+
+def test_a_trailing_initial_still_requires_its_locality():
+    """The disambiguator is part of the name, not a substitute for the entry
+    shape — a cell that stops at the initial is still not an entry."""
+    text = "Cosponsored by Senators: BAILEY of York, SANBORN, H.\nBe it enacted:\n"
+    assert names(text) == ["BAILEY"]

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -752,26 +752,40 @@ def test_the_particle_arm_does_not_swallow_the_locality_separator():
 
 
 def test_the_particle_arm_does_not_re_open_the_clause_class():
-    """The cases the locality boundary was added to reject must stay rejected
-    now that the name may carry a lowercase middle word."""
+    """The clause class the locality boundary rejects must stay rejected when
+    the cell ALSO engages the particle arm.
+
+    An earlier version of this test used cells with no lowercase word between
+    two capitalised ones -- byte-identical to fixtures two sections up. The
+    locality boundary was rejecting them and the particle arm was never
+    reached, so it asserted nothing about the thing it is named for.
+    """
     for clause in (
-        "MDOT of Augusta shall study the matter.",
-        "PART A of Chapter 12 takes effect on July 1.",
-        "MRSA of Title 5 is amended to read as follows.",
+        "MDOT du BUREAU of Augusta shall study the matter.",
+        "PART de SECTION of Chapter 12 takes effect on July 1.",
+        "TITLE van CHAPTER of Maine is hereby amended.",
     ):
         text = f"Cosponsored by Senators: BAILEY of York, {clause}\n"
         assert names(text) == ["BAILEY"], clause
 
 
-def test_a_denylisted_noun_is_still_dropped_when_it_carries_a_particle():
-    """Widening the arity ceiling to 3 must not let a denylisted word through
-    on a longer name."""
-    text = (
-        "Cosponsored by Senators: BAILEY of York, BOARD of the City of Portland, "
-        "CURRY of Waldo.\nBe it enacted:\n"
-    )
-    assert "BOARD" not in " ".join(names(text))
-    assert names(text) == ["BAILEY", "CURRY"]
+def test_a_denylisted_word_anywhere_in_a_name_drops_it():
+    """The denylist checks every word, and nothing pinned that: mutating
+    is_valid_name to look at only the FIRST word of a multi-word name survived
+    the entire suite.
+
+    The previous fixture here was "BOARD of the City of Portland" -- a
+    one-word name with no particle, already covered by the single-word case
+    above, so neither the arity ceiling nor the particle arm was involved.
+    """
+    for cell in (
+        "SMITH BOARD of Portland",  # denylisted second word
+        "CORNELL du BOARD of Brunswick",  # ...behind a particle
+        "BOARD du CORNELL of Brunswick",  # ...and in front of one
+        "SMITH COUNTY of Portland",
+    ):
+        text = f"Cosponsored by Senators: BAILEY of York, {cell}, CURRY of Waldo.\n"
+        assert names(text) == ["BAILEY", "CURRY"], cell
 
 
 def test_the_disambiguator_lookahead_does_not_glue_ordinary_cells_together():
@@ -943,6 +957,40 @@ def test_the_arity_cap_matches_what_the_pattern_can_emit():
     longest = _ROSTER_ENTRY.match("CORNELL du HOUX, J. of Brunswick")
     assert longest is not None, "the maximal shape must still be a well-formed entry"
     assert len(longest.group("name").split()) == _ROSTER_MAX_NAME_WORDS
+
+    # The other direction, which the first version of this test left open: it
+    # killed "raise the cap" but not "widen the pattern past the cap". Making
+    # the initial group repeatable survived — the exact drift this guards.
+    # Anything the pattern accepts must fit under the cap, or the surplus is
+    # matched and then silently discarded by is_valid_name.
+    for cell in (
+        "CORNELL du HOUX, J., K. of Brunswick",  # repeatable initial group
+        "CORNELL du de van HOUX of Brunswick",  # repeatable particle
+        "CORNELL du HOUX du MAINE of Brunswick",
+        "ONE TWO THREE FOUR of Augusta",
+        "SANBORN, H., J., K. of Cumberland",
+    ):
+        match = _ROSTER_ENTRY.match(cell)
+        if match is not None:
+            assert len(match.group("name").split()) <= _ROSTER_MAX_NAME_WORDS, cell
+
+
+def test_a_name_carries_at_most_one_particle_and_one_initial():
+    """Each is optional and singular. Making either repeatable stays under the
+    arity cap for the short shapes, so the cap alone does not pin it."""
+    from maine_bills.text_extractor import _ROSTER_ENTRY
+
+    for cell, expected in (
+        ("CORNELL du HOUX of Brunswick", "CORNELL du HOUX"),
+        ("SANBORN, H. of Cumberland", "SANBORN, H."),
+        ("CORNELL du de HOUX of Brunswick", None),  # two particles
+        # Two initials: the locality must follow the name immediately, so the
+        # whole cell fails rather than the surplus being trimmed.
+        ("SANBORN, H., J. of Cumberland", None),
+    ):
+        match = _ROSTER_ENTRY.match(cell)
+        got = match.group("name") if match else None
+        assert got == expected, cell
 
     # ...and it must survive the whole pipeline, not just the pattern.
     text = "Cosponsored by Senators: CORNELL du HOUX, J. of Brunswick.\n"

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -738,9 +738,15 @@ def test_the_particle_rule_is_the_one_this_file_already_argues_for_localities():
 
 
 def test_the_particle_arm_does_not_swallow_the_locality_separator():
-    """A general "capital word, lowercase word, capital word" name could in
-    principle consume the " of " that bounds the locality. It cannot, because
-    the locality needs an " of " of its own."""
+    """ "of" is excluded from the particle set, and that exclusion is what
+    protects the separator.
+
+    This test was written with the opposite rationale — that a name could not
+    eat the " of " because the locality needs one of its own — and it failed:
+    "BAILEY of York of Cumberland" parsed as the name "BAILEY of York". The
+    original docstring is kept out of the codebase deliberately; it was wrong,
+    and it is the kind of wrong a future reader would have trusted.
+    """
     text = "Cosponsored by Senators: BAILEY of York of Cumberland.\nBe it enacted:\n"
     assert names(text) == ["BAILEY"]
 
@@ -783,3 +789,161 @@ def test_a_trailing_initial_still_requires_its_locality():
     shape — a cell that stops at the initial is still not an entry."""
     text = "Cosponsored by Senators: BAILEY of York, SANBORN, H.\nBe it enacted:\n"
     assert names(text) == ["BAILEY"]
+
+
+# --- review round 2 on #20: the widened patterns needed tests that fail when
+# they get LOOSER, not only when they are deleted.
+#
+# The first round shipped five mutation tests and every one of them was a
+# deletion. An independent review ran eighteen PERMISSIVE mutations against the
+# same suite and seventeen survived. For a construct whose entire recorded
+# history is over-capture regressions, that is the wrong half of the space to
+# have covered. Everything below pins an upper bound.
+
+
+def test_a_conjunction_is_not_a_name_particle():
+    """The first attempt used a shape rule, "two or three lowercase letters",
+    on the theory that an allowlist only covers surnames already seen. But
+    [a-z]{2,3} is a superset of the English connectives, so the rule had no
+    discriminating power: every one of these became a sponsor, including the
+    "MDOT ... of Augusta" that the locality boundary exists to reject."""
+    for cell in (
+        "MDOT and DHHS of Augusta.",
+        "WAYS and MEANS of Funding.",
+        "TAX on SALE of Goods.",
+        "ONE per CENT of Revenue.",
+        "PART or SECTION of Title 5.",
+        "FUNDS to TOWNS of Maine.",
+        "REPORT by BOARD of Portland.",
+    ):
+        text = f"Cosponsored by Senators: BAILEY of York, {cell}\n"
+        assert names(text) == ["BAILEY"], cell
+
+
+def test_only_the_listed_particles_are_accepted():
+    """Surnames are an open class; naming particles are a closed one. That
+    asymmetry is the whole justification for the allowlist.
+
+    Honest note on strength: "the" here is NOT isolating the allowlist. Adding
+    "the" to _ROSTER_PARTICLES leaves this test green, because "The" is already
+    on the title_words denylist and is_valid_name rejects the name on the second
+    guard. That is defence in depth working, not a gap — but the mutation
+    survives, so this assertion cannot be claimed as evidence for the allowlist.
+    "xyz", "for" and "not" are the ones carrying that weight.
+    """
+    for particle in ("du", "de", "van", "von", "la", "le", "di", "da"):
+        text = f"Cosponsored by Senators: CORNELL {particle} HOUX of Brunswick.\n"
+        assert names(text) == [f"CORNELL {particle} HOUX"], particle
+    for junk in ("xyz", "and", "the", "for", "not", "per"):
+        text = f"Cosponsored by Senators: CORNELL {junk} HOUX of Brunswick.\n"
+        assert names(text) == [], junk
+
+
+def test_a_particle_cannot_open_or_close_a_name():
+    """It joins two capitalised words; on its own at either end it is prose."""
+    for cell in ("du HOUX of Brunswick.", "CORNELL du of Brunswick."):
+        text = f"Cosponsored by Senators: BAILEY of York, {cell}\n"
+        assert names(text) == ["BAILEY"], cell
+
+
+def test_the_denylist_still_applies_when_a_word_carries_punctuation():
+    """is_valid_name splits on whitespace, so a denylisted word with a comma
+    attached is a different string. Once the roster path started keeping the
+    trailing disambiguator, "PART, A." split to {"part,", "a."} and walked
+    straight through the filter — handing back the clause class the locality
+    boundary was built to reject."""
+    for cell in (
+        "PART, A. of Chapter 12.",
+        "CITY, A. of Portland.",
+        "TITLE, A. of Maine.",
+        "SECTION, B. of Title 5.",
+    ):
+        text = f"Cosponsored by Senators: BAILEY of York, {cell}\n"
+        assert names(text) == ["BAILEY"], cell
+
+
+def test_the_entry_pattern_accepts_exactly_one_capital_initial():
+    """Asserted on _ROSTER_ENTRY directly, because the behavioural test below
+    cannot isolate it.
+
+    Review found that loosening this group in the pattern — two initials, no
+    period, a lowercase initial — changed no test result. The reason is that
+    _ROSTER_CELL_SPLIT rejects those shapes first, so the cell never reaches the
+    entry pattern intact and the behavioural assertion passes for a reason that
+    has nothing to do with what it claims to check. Two guards in series, and
+    only the outer one was pinned.
+    """
+    from maine_bills.text_extractor import _ROSTER_ENTRY
+
+    ok = _ROSTER_ENTRY.match("SANBORN, H. of Cumberland")
+    assert ok is not None and ok.group("name") == "SANBORN, H."
+
+    for cell in (
+        "SANBORN, H. J. of Cumberland",  # two initials
+        "SANBORN, h. of Cumberland",  # lowercase
+        "SANBORN, HH. of Cumberland",  # not an initial
+        "SANBORN, H of Cumberland",  # no period
+    ):
+        match = _ROSTER_ENTRY.match(cell)
+        assert match is None or match.group("name") == "SANBORN", cell
+
+    # No comma: the initial is not part of the name, so the cell is not an entry.
+    assert _ROSTER_ENTRY.match("SANBORN H. of Cumberland") is None
+
+
+def test_the_disambiguator_is_exactly_one_capital_letter_and_a_period():
+    """The end-to-end half. Kept alongside the pattern-level test above rather
+    than replaced by it: this is the behaviour that actually ships."""
+    for cell in (
+        "SANBORN, H. J. of Cumberland.",  # two initials
+        "SANBORN, h. of Cumberland.",  # lowercase
+        "SANBORN, H of Cumberland.",  # no period
+        "SANBORN H. of Cumberland.",  # no comma
+        "SANBORN, HH. of Cumberland.",  # not an initial
+    ):
+        text = f"Cosponsored by Senators: BAILEY of York, {cell}\n"
+        assert "SANBORN" not in " ".join(names(text)), cell
+
+
+def test_a_name_is_at_most_two_capitalised_words():
+    """Three capitalised words in a row is a phrase, not a surname."""
+    text = "Cosponsored by Senators: BAILEY of York, ONE TWO THREE of Augusta.\n"
+    assert names(text) == ["BAILEY"]
+
+
+def test_the_cell_splitter_protects_only_the_disambiguating_comma():
+    """Asserted on the splitter itself. Going through _extract_sponsors cannot
+    isolate this: a cell the lookahead wrongly protected would also have to be a
+    well-formed entry to change the output, and the shapes that would prove the
+    point ("C. LEWIS of Auburn") fail the entry pattern for an unrelated
+    reason — which is exactly what the first version of this test measured."""
+    from maine_bills.text_extractor import _ROSTER_CELL_SPLIT as split
+
+    # Protected: the comma is inside the name.
+    assert split.split("SANBORN, H. of Cumberland") == ["SANBORN, H. of Cumberland"]
+
+    # Not protected: no " of " after the initial, so it is an ordinary boundary.
+    assert split.split("SANBORN, H. Cumberland") == ["SANBORN", " H. Cumberland"]
+    # Not an initial at all.
+    assert split.split("BAILEY of York, HH. of Cumberland") == [
+        "BAILEY of York",
+        " HH. of Cumberland",
+    ]
+    # An ordinary roster is untouched.
+    assert split.split("BAILEY of York, CURRY of Waldo") == ["BAILEY of York", " CURRY of Waldo"]
+
+
+def test_the_arity_cap_matches_what_the_pattern_can_emit():
+    """The cap and the pattern drifted apart once already: the comment claimed
+    three tokens while the regex could emit four ("CORNELL du HOUX, J."), so
+    that name matched and was then silently discarded by the cap. Derived from
+    the pattern here rather than asserted in a comment."""
+    from maine_bills.text_extractor import _ROSTER_ENTRY, _ROSTER_MAX_NAME_WORDS
+
+    longest = _ROSTER_ENTRY.match("CORNELL du HOUX, J. of Brunswick")
+    assert longest is not None, "the maximal shape must still be a well-formed entry"
+    assert len(longest.group("name").split()) == _ROSTER_MAX_NAME_WORDS
+
+    # ...and it must survive the whole pipeline, not just the pattern.
+    text = "Cosponsored by Senators: CORNELL du HOUX, J. of Brunswick.\n"
+    assert names(text) == ["CORNELL du HOUX, J."]


### PR DESCRIPTION
Closes #20. Both defects were deferred from #16 because neither fix is a one-liner, and both **cascade** — the failing cell ends the run, so every cosponsor behind it is lost too. That cascade turns out to be almost the entire cost.

> **Round 2 pushed** (`12c2fce1`). Independent review found the first round widened three constructs and tested none of the widening — 17 of 18 permissive mutations survived, and two of the widenings let through things that are not people. Both are fixed; see *What round 2 changed* at the bottom. Rebased onto `dc8f35b7`.

## 1. `SANBORN, H. of Cumberland`

Maine distinguishes two sitting members who share a surname with a trailing initial. Cells were split on every comma, so the first cell was bare `SANBORN` — no locality, so not an entry at all, so the run ended and `VITELLI` went with it.

`_ROSTER_CELL_SPLIT` now refuses to split on a comma followed by `<single capital>. of `, and the name group carries the initial. The lookahead is deliberately narrow: a locality cannot begin that way, because a locality only ever appears *after* an " of " itself.

**The disambiguator is kept in the extracted string.** Dropping it back to `SANBORN` would merge two different legislators, and it is what the document says. Review confirmed the downstream consequence empirically: `SANBORN, H.` matches as `unmatched` with all five enrichment fields null and confidence 0.0 — no wrong-person guess — and bare `SANBORN` would have been `ambiguous`, also null. Nothing is lost relative to the alternative. Filed as #27, because the initial is exactly the information needed to resolve it and 164 mentions on session 129 alone are currently left unmatched.

## 2. `CORNELL du HOUX of Brunswick`

The name group required every word capitalised and allowed at most two. As #20 points out, `text_extractor.py` already argues that *localities* must not require every word capitalised, since "Isle au Haut" has a lowercase particle, and then applied exactly that rule to names.

The particle is an **allowlist**. My first attempt used a shape rule and the reasoning was wrong — see below.

`is_valid_name`'s arity cap is raised on the roster path only, via an explicit `max_words` argument. The title-adjoining patterns keep 2 — they have neither a particle arm nor an initial.

## Measurement

Over real published `text`, `main` vs. this branch:

| Session | Bills | Changed | Mentions | Distinct gained | Distinct lost |
|---|---|---|---|---|---|
| 125 | 3,501 | 36 | 11,210 → 11,699 | 122 | **0** |
| 129 | 3,559 | 147 | 12,929 → 13,136 | 5 | **0** |
| 131 | 4,072 | **0** | 11,019 → 11,019 | 0 | **0** |
| **Total** | **11,132** | **183** | **35,158 → 35,854 (+696)** | **126** | **0** |

**Session 131 contributes nothing** — neither defective shape was sitting in that legislature. The first version of this PR body presented this as a three-session measurement without saying so, which overstated the breadth of the evidence.

Reproduced independently by the reviewer to the same four figures.

**The cascade is the cost.** Only 3 of the 126 gained names are the defective shapes themselves — `SANBORN, H.`, `SANBORN, L.`, `CORNELL du HOUX`, 200 mentions between them. The other 496 mentions are ordinary surnames that merely sat *behind* a failing cell. `CORNELL du HOUX` sorts first alphabetically, so on session 125 it took whole rosters with it:

```
125 LD0695: 3 -> 10   +[CORNELL du HOUX, GOODE, HARLOW, HINCK, McCABE, ROCHELO, STUCKEY]
125 LD0600: 4 -> 11   +[CORNELL du HOUX, DION, FITTS, HAMPER, HINCK, LUCHINI, WALSH INNES]
125 LD0026: 2 ->  9   +[CORNELL du HOUX, HARVELL, KESCHL, LONGSTAFF, MORISSETTE, PICCHIOTTI, WEAVER]
```

All 126 gained names inspected by hand, and independently by the reviewer. Every one is a real Maine surname — `MONAGHAN-DERRIG`, `WALSH INNES`, `STRANG BURGESS`, `MacDONALD`, `SOCTOMAH`. No acronyms, no institutional nouns.

> **Method note:** `getPDF.asp`, which the #16 reviewer used to sample real bills, now answers HTTP 200 with a **zero-byte body** for every paper — verified against four papers across three sessions, while `display_ps.asp` still serves normally. Issue #20 recommends reusing that endpoint; it no longer works. This measurement is against the published `text` column instead.

## Tier decision

**Tier 2**, confirmed by the reviewer. `docs/GOVERNANCE.md` names "extraction/matching/scraper code, tests" as Tier 2 explicitly, and #16 changed the same file under the same tier. No `schema.py`, `publish.py`, `.github/`, or dependency changes; no column added, renamed, or retyped. The `sponsors` column's *values* change, which is data, not schema.

## Risk

Sponsor extraction runs on every session's scrape, so a false positive enters the published dataset. Blast radius is the `sponsors` column and the five v2 columns derived from it. The widened name pattern is the risk surface; the three guards bounding it — `_ROSTER_SURNAME`, the denylist, and the mandatory ` of <locality>` — are unchanged and still mutation-tested, and the denylist is now strictly stronger than before (see round 2, item 2).

## Checks

- 573 tests passing; `ruff check` / `ruff format --check` clean on `src/`, `tests/`, `scripts/`.
- 24 new tests. Half of them assert an **upper bound** — that the widened patterns reject things — which is the half the first round was missing.
- Mutation-tested **in place** (the package is installed editable, so mutating a copy makes every mutation appear to survive). Sanity check: disabling the roster sweep → 55 failures. Permissive set: **16 of 17 killed**.

The one survivor is honest and documented in the test: adding `the` to the particle allowlist stays green, because `The` is on the `title_words` denylist and the second guard catches it. Defence in depth working — but it means that assertion cannot be claimed as evidence for the allowlist, and the test says so.

## Rollback

Revert the commits. No state, no migration. Already-published parquet is untouched until a re-scrape, which is #13's job.

<details>
<summary>What round 2 changed</summary>

**1. The particle arm admitted English connectives.** I used a shape rule — "two or three lowercase letters" — arguing that an allowlist "only ever covers the surnames already seen." That argument does not survive contact with the vocabulary: `[a-z]{2,3}` is a superset of `and/or/on/to/by/in/at/as/per`, so the rule had **no discriminating power at all**. The reviewer ran these through the extractor and every one became a sponsor:

```
MDOT and DHHS of Augusta   ->  "MDOT and DHHS"
WAYS and MEANS of Funding  ->  "WAYS and MEANS"
TAX on SALE of Goods       ->  "TAX on SALE"
ONE per CENT of Revenue    ->  "ONE per CENT"
```

`MDOT ... of Augusta` is the exact string the locality boundary was built to reject; a conjunction handed it straight back. It is an allowlist now. The asymmetry I missed: surnames are an open class, but naming **particles are a closed one** — a few dozen across the European traditions. A new legislator will not invent a particle.

**2. The denylist could be bypassed with punctuation.** `is_valid_name` splits on whitespace, so once the roster path kept the trailing disambiguator, `PART, A. of Chapter 12` split to `{"part,", "a."}` — and `"part,"` is not `"part"`. Words are stripped of punctuation before the comparison now, which makes the denylist strictly stronger than it was before this PR.

**3. `_ROSTER_MAX_NAME_WORDS` was a live bug, not a stale comment.** It said 3 while the pattern could already emit four tokens (`CORNELL du HOUX, J.`), so a particle surname carrying an initial matched the pattern and was then silently discarded by the cap — and *without ending the run*, since a name rejected on a clean cell is skipped rather than cascaded. It cost exactly one sponsor with nothing to show for it. Now 4, and coupled to the pattern by a test rather than by a comment, which is what let them drift apart.

**4. Two of my new tests were passing for the wrong reason.** Loosening the initial's shape inside `_ROSTER_ENTRY` changed nothing observable, because `_ROSTER_CELL_SPLIT` rejects those cells first — two guards in series with only the outer one pinned. Both are now asserted on the pattern directly as well as end-to-end.

**5. A disproved docstring was left in the tests.** `test_the_particle_arm_does_not_swallow_the_locality_separator` still carried the rationale the test itself had disproved. Corrected, with a note that the original was wrong — flagged by Copilot.

</details>