### PR TITLE
[Tier-1] the gated publish path for the `actions` config

### DIFF
--- a/.github/workflows/data-run.yml
+++ b/.github/workflows/data-run.yml
@@ -27,6 +27,7 @@ on:
           - fetch-status-sample
           - run-matching
           - build-actions
+          - publish-actions
           - custom
       sessions:
         description: "Space-separated session numbers (e.g. '132' or '132 121')"
@@ -34,10 +35,20 @@ on:
         required: false
         default: "132"
       run_id:
-        description: "For build-actions: space-separated run id(s) holding the actions-<session> artifacts"
+        description: "For build-actions/publish-actions: space-separated run id(s) holding the artifacts"
         type: string
         required: false
         default: ""
+      repo_id:
+        description: "For publish-actions: the HuggingFace dataset repo"
+        type: string
+        required: false
+        default: "pem207/maine-bills"
+      dry_run:
+        description: "For publish-actions: validate and report, upload nothing. Defaults to TRUE."
+        type: boolean
+        required: false
+        default: true
       extra_args:
         description: "Extra args (run-matching passthrough, or full command for 'custom': runs `uv run <extra_args>`)"
         type: string
@@ -486,6 +497,77 @@ jobs:
   # from the backfill so a session can be re-run without rebuilding everything,
   # and separate from publishing so a human sees the parquet before it ships --
   # uploading is Tier-1 and goes through the huggingface-publish gate.
+  # The only job in this workflow that WRITES to HuggingFace, and the only one
+  # declaring `environment:`. That declaration is the gate: the environment has
+  # a required reviewer, and HF_TOKEN exists nowhere else, so a dispatch cannot
+  # reach the Hub without the owner approving that specific run.
+  #
+  # Split from build-actions on purpose. Building is cheap, ungated and
+  # repeatable; publishing is neither. Keeping them one job would mean every
+  # rebuild queued for human approval, which trains people to click through it.
+  #
+  # dry_run defaults to TRUE, so the accident-shaped dispatch -- pick the task,
+  # paste a run id, hit go -- validates and reports instead of uploading.
+  publish-actions:
+    if: inputs.task == 'publish-actions'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: huggingface-publish
+    permissions:
+      contents: read
+      actions: read # to download the built config from the build-actions run
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Validate run_id
+        env:
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          case "$RUN_ID" in
+            "" | *[!0-9\ ]*)
+              echo "::error::publish-actions needs run_id: the numeric run id of the build-actions run holding the actions-config artifact"
+              exit 1
+              ;;
+          esac
+
+      - name: Download the built config
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          set -e
+          mkdir -p data/actions-parquet
+          gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name actions-config --dir data/actions-parquet
+          echo "Collected:"
+          find data/actions-parquet -name '*.parquet' | sort
+
+      # Re-validated here rather than trusted: the build ran on a different
+      # runner and its artifact can arrive truncated. A bad session must fail
+      # before anything is uploaded, because correcting the Hub means a visible
+      # bad revision rather than a red check.
+      - name: Publish
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          REPO_ID: ${{ inputs.repo_id }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -e
+          if [ "$DRY_RUN" = "true" ]; then
+            uv run python scripts/publish_actions_config.py \
+              --input data/actions-parquet --repo-id "$REPO_ID" --dry-run
+          else
+            uv run python scripts/publish_actions_config.py \
+              --input data/actions-parquet --repo-id "$REPO_ID"
+          fi
+
   build-actions:
     if: inputs.task == 'build-actions'
     runs-on: ubuntu-latest

--- a/.github/workflows/data-run.yml
+++ b/.github/workflows/data-run.yml
@@ -530,9 +530,14 @@ jobs:
         env:
           RUN_ID: ${{ inputs.run_id }}
         run: |
+          # Digits only, NO spaces. build-actions accepts several run ids
+          # because sessions can come from several backfills; publish-actions
+          # takes exactly one build, and a space-separated pair would be handed
+          # to `gh run download` as a single argument and fail there instead of
+          # here, after the environment approval had already been spent.
           case "$RUN_ID" in
-            "" | *[!0-9\ ]*)
-              echo "::error::publish-actions needs run_id: the numeric run id of the build-actions run holding the actions-config artifact"
+            "" | *[!0-9]*)
+              echo "::error::publish-actions needs run_id: ONE numeric run id of the build-actions run holding the actions-config artifact"
               exit 1
               ;;
           esac
@@ -553,20 +558,26 @@ jobs:
       # runner and its artifact can arrive truncated. A bad session must fail
       # before anything is uploaded, because correcting the Hub means a visible
       # bad revision rather than a red check.
+      # Two steps rather than one branch, so HF_TOKEN is never placed in the
+      # environment of the run that cannot use it. A dry run reads local
+      # parquet and reports; handing it a write-capable credential it has no
+      # use for is exactly the exposure the gate exists to limit.
+      - name: Validate (dry run)
+        if: inputs.dry_run
+        env:
+          REPO_ID: ${{ inputs.repo_id }}
+        run: |
+          uv run python scripts/publish_actions_config.py \
+            --input data/actions-parquet --repo-id "$REPO_ID" --dry-run
+
       - name: Publish
+        if: ${{ !inputs.dry_run }}
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           REPO_ID: ${{ inputs.repo_id }}
-          DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          set -e
-          if [ "$DRY_RUN" = "true" ]; then
-            uv run python scripts/publish_actions_config.py \
-              --input data/actions-parquet --repo-id "$REPO_ID" --dry-run
-          else
-            uv run python scripts/publish_actions_config.py \
-              --input data/actions-parquet --repo-id "$REPO_ID"
-          fi
+          uv run python scripts/publish_actions_config.py \
+            --input data/actions-parquet --repo-id "$REPO_ID"
 
   build-actions:
     if: inputs.task == 'build-actions'

--- a/scripts/publish_actions_config.py
+++ b/scripts/publish_actions_config.py
@@ -1,0 +1,107 @@
+"""Upload a built `actions` config to HuggingFace (sprint node N3).
+
+Takes what `build_actions_config.py` wrote and uploads it, then re-syncs the
+dataset card so the new per-session configs are declared.
+
+**This is the gated half.** It is the only script here that writes to the Hub,
+so it runs exclusively inside the `huggingface-publish` environment, whose
+required reviewer is the repo owner and whose secret is the only place HF_TOKEN
+exists (docs/GOVERNANCE.md). Building is deliberately a separate, ungated step.
+
+Re-validates before uploading rather than trusting the artifact. The build and
+the publish are different jobs on different runners, and an artifact can arrive
+truncated or partial; a session that fails validation here must not reach the
+Hub, where correcting it means a visible bad revision rather than a red check.
+
+Usage:
+    uv run python scripts/publish_actions_config.py \\
+        --input data/actions-parquet --repo-id pem207/maine-bills
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pandas as pd  # noqa: E402
+
+from maine_bills.actions_config import COLUMNS, ActionsConfigError  # noqa: E402
+from maine_bills.publish import publish_actions_config, sync_dataset_card  # noqa: E402
+
+logger = logging.getLogger("publish_actions_config")
+
+
+def validate(parquet_dir: Path) -> list[int]:
+    """Re-read every parquet and check it before anything is uploaded.
+
+    Checks the whole set first, then uploads — so a bad session eleven files in
+    does not leave the Hub holding ten uploaded ones.
+    """
+    sessions = sorted(int(d.name) for d in parquet_dir.iterdir() if d.is_dir() and d.name.isdigit())
+    if not sessions:
+        raise ActionsConfigError(f"No session directories under {parquet_dir}")
+
+    for session in sessions:
+        path = parquet_dir / str(session) / "train-00000-of-00001.parquet"
+        if not path.exists():
+            raise ActionsConfigError(f"{path} is missing; the build did not finish")
+
+        frame = pd.read_parquet(path)
+        if list(frame.columns) != COLUMNS:
+            raise ActionsConfigError(
+                f"{path}: columns {list(frame.columns)} do not match the published layout"
+            )
+        if frame.empty:
+            raise ActionsConfigError(
+                f"{path}: no rows. A Maine session has ~2,000 bills; zero means the build "
+                f"produced an empty file."
+            )
+        if frame["ld_number"].duplicated().any():
+            raise ActionsConfigError(f"{path}: duplicate ld_number would multiply rows on join")
+        if set(frame["session"].unique()) != {session}:
+            raise ActionsConfigError(
+                f"{path}: holds sessions {sorted(frame['session'].unique())}, not {session}"
+            )
+        logger.info(
+            f"Session {session}: {len(frame)} bills, {int(frame['action_count'].sum())} actions"
+        )
+
+    return sessions
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--input", type=Path, required=True, help="Directory of built parquet")
+    parser.add_argument("--repo-id", required=True, help="HuggingFace dataset repo")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and report what would be uploaded, then stop without writing.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
+    args = parse_args(argv)
+
+    try:
+        sessions = validate(args.input)
+    except ActionsConfigError as e:
+        logger.error(str(e))
+        return 1
+
+    if args.dry_run:
+        logger.info(f"Dry run: would upload sessions {sessions} to {args.repo_id}")
+        return 0
+
+    publish_actions_config(args.input, args.repo_id)
+    sync_dataset_card(args.repo_id)
+    logger.info(f"Published {len(sessions)} actions sessions to {args.repo_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/maine_bills/publish.py
+++ b/src/maine_bills/publish.py
@@ -6,6 +6,16 @@ from huggingface_hub import HfApi
 
 logger = logging.getLogger(__name__)
 
+# Where each config lives in the repo.
+#
+# The actions config is deliberately NOT under `data/`. The default "all" config
+# globs `data/**/*.parquet`, so an actions parquet placed anywhere beneath it
+# would be loaded as if it were bill rows -- a different schema silently unioned
+# into the config most consumers use without naming it. A sibling top-level
+# directory keeps the two globs disjoint by construction.
+BILLS_ROOT = "data"
+ACTIONS_ROOT = "actions"
+
 DATASET_CARD_TEMPLATE = """\
 ---
 license: mit
@@ -30,7 +40,12 @@ configs:
     data_files:
       - split: train
         path: "data/**/*.parquet"
+  - config_name: "actions"
+    data_files:
+      - split: train
+        path: "actions/**/*.parquet"
 {session_configs}
+{actions_configs}
 ---
 
 # Maine Legislative Bills
@@ -38,8 +53,8 @@ configs:
 Full text of bills and amendments from the Maine State Legislature,
 extracted from PDFs published by the Law and Legislative Reference Library.
 
-**Dataset version: v2.** Adds four nullable sponsor-enrichment columns
-(`sponsor_ids`, `sponsor_parties`, `sponsor_districts`,
+**Dataset version: v2.** Adds five nullable sponsor-enrichment columns
+(`sponsor_chambers`, `sponsor_ids`, `sponsor_parties`, `sponsor_districts`,
 `sponsor_match_confidence`) linking extracted sponsor names to OpenStates
 legislator records. All v1 columns are unchanged, so existing consumers are
 unaffected; records scraped without enrichment carry null entries in the new
@@ -58,7 +73,24 @@ ds = load_dataset("pem207/maine-bills", "132")
 
 # Stream without downloading
 ds = load_dataset("pem207/maine-bills", streaming=True)
+
+# Legislative history: one row per bill, with its committee docket
+actions = load_dataset("pem207/maine-bills", "actions")
+actions_132 = load_dataset("pem207/maine-bills", "actions-132")
 ```
+
+## Configs
+
+| Config | Rows | What |
+|---|---|---|
+| `all` (default) | one per **document** | Bill and amendment text. |
+| `<session>` e.g. `132` | one per document | The same, for a single session. |
+| `actions` | one per **bill** | Legislative history and docket. |
+| `actions-<session>` | one per bill | The same, for a single session. |
+
+Amendments are separate rows in `all` and share their parent's `ld_number`.
+The two families do not share a schema and live under separate paths, so
+the default `all` config never mixes them.
 
 ## Source
 
@@ -89,9 +121,62 @@ endorsed by nor affiliated with the Maine State Legislature.
 | `source_filename` | string | Original filename without extension |
 | `scraped_at` | string | ISO 8601 timestamp of extraction |
 
-The four `sponsor_*` enrichment columns are index-aligned with `sponsors`:
+The five `sponsor_*` enrichment columns are index-aligned with `sponsors`:
 entry *i* of each list describes `sponsors[i]`. `sponsors` itself is always
 the verbatim extracted name and is never rewritten by enrichment.
+
+## The `actions` config
+
+One row per **bill**, carrying the bill-level status fields and its committee
+docket as a nested list.
+
+| Column | Type | Description |
+|---|---|---|
+| `session` | int | Legislative session number |
+| `ld_number` | string | Legislative Document number (zero-padded) — the join key |
+| `paper` | string | Paper number, e.g. "SP 29" / "HP 1289" |
+| `title` | string | Bill title as printed on the status page |
+| `flags` | list | Status flags, e.g. EMERGENCY |
+| `committee` | string | Committee of referral, or null if never referred |
+| `referred_date` | string | ISO date of referral, or null |
+| `final_disposition` | string | e.g. PUBLIC LAW, DIED BETWEEN HOUSES, or null |
+| `final_disposition_date` | string | ISO date, or null |
+| `governor_action` | string | e.g. Signed, Vetoed, or null |
+| `governor_action_date` | string | ISO date, or null |
+| `chaptered_law` | string | e.g. "ACTPUB Chapter 33", or null |
+| `actions` | list of struct | The docket: `{{date, action, result, raw_date}}` per entry |
+| `action_count` | int | `len(actions)`, carried so it can be filtered without exploding |
+| `source_url` | string | Direct URL to the status page |
+
+### Joining to the bills config
+
+The key is `(session, ld_number)`, zero-padded on both sides. The join is
+**one-to-many** from this side: amendments in the bills config share their
+parent's `ld_number`, because a bill's status describes the bill, not each
+printed document. A bill with several amendments therefore matches several
+rows in `all`.
+
+```python
+import pandas as pd
+
+bills = load_dataset("pem207/maine-bills", "132")["train"].to_pandas()
+acts = load_dataset("pem207/maine-bills", "actions-132")["train"].to_pandas()
+merged = bills.merge(acts, on=["session", "ld_number"], how="left", suffixes=("", "_status"))
+
+# Long format, if you want one row per docket entry:
+long = acts.explode("actions")
+```
+
+### Nulls
+
+Nulls are meaningful and are never filled in. `committee = None` means the bill
+was never referred — it does **not** mean the referral failed to parse. A status
+page that does not parse is recorded as a failure and excluded from the config
+rather than written as an empty row, so an absent `ld_number` and a null field
+are different statements.
+
+Three bills across sessions 121–132 have no status page at all and are absent
+from this config while present in `all`.
 
 ## Sponsor enrichment methodology
 
@@ -137,14 +222,73 @@ def publish_session(df: pd.DataFrame, session: int, repo_id: str, local_dir: Pat
     logger.info(f"Uploaded {path_in_repo} ({len(df)} records)")
 
 
+def publish_actions_config(parquet_dir: Path, repo_id: str) -> list[int]:
+    """Upload a built `actions` config, one parquet per session.
+
+    ``parquet_dir`` is what ``scripts/build_actions_config.py`` writes:
+    ``<dir>/<session>/train-00000-of-00001.parquet`` plus a build-summary.json,
+    which is not uploaded — it describes the build, not the data.
+
+    Returns the sessions uploaded, in order. Refuses an empty directory rather
+    than reporting success, because "nothing to upload" and "uploaded nothing"
+    look identical in a log otherwise.
+    """
+    api = HfApi()
+
+    sessions = sorted(int(d.name) for d in parquet_dir.iterdir() if d.is_dir() and d.name.isdigit())
+    if not sessions:
+        raise ValueError(
+            f"No session directories under {parquet_dir}. Run build_actions_config.py first."
+        )
+
+    for session in sessions:
+        local_path = parquet_dir / str(session) / "train-00000-of-00001.parquet"
+        if not local_path.exists():
+            raise FileNotFoundError(
+                f"{local_path} is missing though its directory exists — the build did not finish."
+            )
+        path_in_repo = f"{ACTIONS_ROOT}/{session}/train-00000-of-00001.parquet"
+        api.upload_file(
+            path_or_fileobj=str(local_path),
+            path_in_repo=path_in_repo,
+            repo_id=repo_id,
+            repo_type="dataset",
+            commit_message=f"Update actions config for session {session}",
+        )
+        logger.info(f"Uploaded {path_in_repo}")
+
+    return sessions
+
+
+def _session_dirs(api: HfApi, repo_id: str, root: str) -> list[int]:
+    """Session numbers directly under ``root`` in the repo, ascending.
+
+    Returns [] when the directory does not exist yet — the actions config has
+    not been published on every repo this code runs against, and a missing
+    directory is a normal state rather than an error.
+    """
+    try:
+        items = api.list_repo_tree(repo_id, repo_type="dataset", path_in_repo=root)
+    except Exception as e:  # EntryNotFoundError and its transport-specific kin
+        logger.info(f"No {root}/ directory in {repo_id} ({type(e).__name__}); skipping its configs")
+        return []
+    return sorted(int(i.path.split("/")[-1]) for i in items if i.path.split("/")[-1].isdigit())
+
+
+def _config_block(name: str, path: str) -> list[str]:
+    return [
+        f'  - config_name: "{name}"',
+        "    data_files:",
+        "      - split: train",
+        f'        path: "{path}"',
+    ]
+
+
 def sync_dataset_card(repo_id: str) -> None:
     """Regenerate the HF dataset README.md to include configs for all sessions."""
     api = HfApi()
 
-    repo_items = api.list_repo_tree(repo_id, repo_type="dataset", path_in_repo="data")
-    sessions = sorted(
-        int(item.path.split("/")[-1]) for item in repo_items if item.path.split("/")[-1].isdigit()
-    )
+    sessions = _session_dirs(api, repo_id, BILLS_ROOT)
 
     if not sessions:
         logger.warning("No session directories found in repo; skipping card sync")
@@ -152,16 +296,19 @@ def sync_dataset_card(repo_id: str) -> None:
 
     session_config_lines = []
     for s in sessions:
-        session_config_lines.extend(
-            [
-                f'  - config_name: "{s}"',
-                "    data_files:",
-                "      - split: train",
-                f'        path: "data/{s}/*.parquet"',
-            ]
-        )
+        session_config_lines.extend(_config_block(str(s), f"{BILLS_ROOT}/{s}/*.parquet"))
 
-    readme_content = DATASET_CARD_TEMPLATE.format(session_configs="\n".join(session_config_lines))
+    # The actions config is additive: a repo that has never published one still
+    # gets a correct card, just without those entries.
+    actions_sessions = _session_dirs(api, repo_id, ACTIONS_ROOT)
+    actions_config_lines = []
+    for s in actions_sessions:
+        actions_config_lines.extend(_config_block(f"actions-{s}", f"{ACTIONS_ROOT}/{s}/*.parquet"))
+
+    readme_content = DATASET_CARD_TEMPLATE.format(
+        session_configs="\n".join(session_config_lines),
+        actions_configs="\n".join(actions_config_lines),
+    )
     api.upload_file(
         path_or_fileobj=readme_content.encode("utf-8"),
         path_in_repo="README.md",
@@ -169,6 +316,10 @@ def sync_dataset_card(repo_id: str) -> None:
         repo_type="dataset",
         commit_message=(
             f"Sync dataset card: {len(sessions)} sessions ({sessions[0]}–{sessions[-1]})"
+            + (f", {len(actions_sessions)} actions configs" if actions_sessions else "")
         ),
     )
-    logger.info(f"Dataset card updated with {len(sessions)} session configs")
+    logger.info(
+        f"Dataset card updated with {len(sessions)} session configs "
+        f"and {len(actions_sessions)} actions configs"
+    )

--- a/src/maine_bills/publish.py
+++ b/src/maine_bills/publish.py
@@ -3,8 +3,13 @@ from pathlib import Path
 
 import pandas as pd
 from huggingface_hub import HfApi
+from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError
 
 logger = logging.getLogger(__name__)
+
+# The only failures that mean "this directory is not there yet". Anything else —
+# auth, 5xx, DNS — must surface rather than be read as an empty repo.
+_NOT_FOUND = (EntryNotFoundError, RepositoryNotFoundError, FileNotFoundError)
 
 # Where each config lives in the repo.
 #
@@ -269,7 +274,12 @@ def _session_dirs(api: HfApi, repo_id: str, root: str) -> list[int]:
     """
     try:
         items = api.list_repo_tree(repo_id, repo_type="dataset", path_in_repo=root)
-    except Exception as e:  # EntryNotFoundError and its transport-specific kin
+    except _NOT_FOUND as e:
+        # ONLY not-found. Catching Exception here swallowed auth failures, 5xx
+        # and network errors as "directory missing", so a transient outage would
+        # publish a card with the actions configs quietly absent — and the job
+        # would still go green. A card that is wrong is worse than a job that
+        # fails, because nothing downstream re-checks it.
         logger.info(f"No {root}/ directory in {repo_id} ({type(e).__name__}); skipping its configs")
         return []
     return sorted(int(i.path.split("/")[-1]) for i in items if i.path.split("/")[-1].isdigit())

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -300,3 +300,27 @@ def test_the_card_is_still_correct_before_actions_is_ever_published(mocker):
     # The repo-wide `actions` config stays declared; it globs an empty
     # directory harmlessly and means publishing later needs no card change.
     assert 'config_name: "actions"' in front_matter
+
+
+def test_a_real_hub_failure_is_not_read_as_a_missing_directory(mocker):
+    """Catching Exception here swallowed auth failures, 5xx and network errors
+    as "directory missing", so a transient outage would publish a card with the
+    actions configs quietly absent — and the job would still go green. A wrong
+    card is worse than a failed job, because nothing downstream re-checks it."""
+    import pytest
+
+    from maine_bills.publish import sync_dataset_card
+
+    api = MagicMock()
+
+    def tree_or_fail(repo_id, repo_type, path_in_repo):
+        if path_in_repo == "actions":
+            raise ConnectionError("503 from the hub")
+        return tree(["data/132"])
+
+    api.list_repo_tree.side_effect = tree_or_fail
+    mocker.patch("maine_bills.publish.HfApi", return_value=api)
+
+    with pytest.raises(ConnectionError):
+        sync_dataset_card("pem207/maine-bills")
+    api.upload_file.assert_not_called()

--- a/tests/unit/test_publish.py
+++ b/tests/unit/test_publish.py
@@ -162,3 +162,141 @@ def test_sync_dataset_card_skips_non_session_entries(mocker):
     # "README.md" should not appear as a config_name entry
     assert 'config_name: "README.md"' not in readme
     assert 'config_name: "131"' in readme
+
+
+# --- the actions config ---
+#
+# The hazard these are about is not upload mechanics. It is the default config
+# quietly acquiring a second schema: `all` globs data/**/*.parquet, so an
+# actions parquet placed anywhere beneath data/ would load as bill rows for
+# every consumer who never names a config.
+
+
+def actions_dir(tmp_path, sessions=(131, 132)):
+    for s in sessions:
+        d = tmp_path / str(s)
+        d.mkdir(parents=True)
+        pd.DataFrame([{"session": s, "ld_number": "0001", "action_count": 0}]).to_parquet(
+            d / "train-00000-of-00001.parquet"
+        )
+    (tmp_path / "build-summary.json").write_text("{}")
+    return tmp_path
+
+
+def test_actions_are_published_outside_the_bills_glob(tmp_path, mocker):
+    """data/**/*.parquet must never match an actions file."""
+    from maine_bills.publish import publish_actions_config
+
+    api = MagicMock()
+    mocker.patch("maine_bills.publish.HfApi", return_value=api)
+
+    publish_actions_config(actions_dir(tmp_path), "pem207/maine-bills")
+
+    paths = [c.kwargs["path_in_repo"] for c in api.upload_file.call_args_list]
+    assert paths == [
+        "actions/131/train-00000-of-00001.parquet",
+        "actions/132/train-00000-of-00001.parquet",
+    ]
+    assert not any(p.startswith("data/") for p in paths)
+
+
+def test_the_default_config_glob_cannot_reach_the_actions_path():
+    """Asserted on the template itself, so a later edit that moves actions under
+    data/ fails here rather than in someone's load_dataset call."""
+    import fnmatch
+
+    from maine_bills.publish import ACTIONS_ROOT, DATASET_CARD_TEMPLATE
+
+    assert 'path: "data/**/*.parquet"' in DATASET_CARD_TEMPLATE
+    assert not fnmatch.fnmatch(
+        f"{ACTIONS_ROOT}/132/train-00000-of-00001.parquet", "data/**/*.parquet"
+    )
+
+
+def test_the_build_summary_is_not_uploaded(tmp_path, mocker):
+    """It describes the build, not the data, and would land in the repo root."""
+    from maine_bills.publish import publish_actions_config
+
+    api = MagicMock()
+    mocker.patch("maine_bills.publish.HfApi", return_value=api)
+    publish_actions_config(actions_dir(tmp_path), "pem207/maine-bills")
+
+    assert not any("summary" in c.kwargs["path_in_repo"] for c in api.upload_file.call_args_list)
+
+
+def test_an_empty_directory_is_refused_not_reported_as_success(tmp_path, mocker):
+    """ "Nothing to upload" and "uploaded nothing" look identical in a log."""
+    import pytest
+
+    from maine_bills.publish import publish_actions_config
+
+    mocker.patch("maine_bills.publish.HfApi")
+    (tmp_path / "empty").mkdir()
+    with pytest.raises(ValueError, match="No session directories"):
+        publish_actions_config(tmp_path / "empty", "pem207/maine-bills")
+
+
+def test_a_session_directory_with_no_parquet_is_refused(tmp_path, mocker):
+    """A half-finished build leaves the directory but not the file."""
+    import pytest
+
+    from maine_bills.publish import publish_actions_config
+
+    mocker.patch("maine_bills.publish.HfApi")
+    (tmp_path / "132").mkdir(parents=True)
+    with pytest.raises(FileNotFoundError, match="did not finish"):
+        publish_actions_config(tmp_path, "pem207/maine-bills")
+
+
+# --- the card ---
+
+
+def tree(paths):
+    return [MagicMock(path=p) for p in paths]
+
+
+def test_the_card_gains_a_config_per_actions_session(mocker):
+    from maine_bills.publish import sync_dataset_card
+
+    api = MagicMock()
+    api.list_repo_tree.side_effect = lambda repo_id, repo_type, path_in_repo: (
+        tree(["data/131", "data/132"]) if path_in_repo == "data" else tree(["actions/131"])
+    )
+    mocker.patch("maine_bills.publish.HfApi", return_value=api)
+
+    sync_dataset_card("pem207/maine-bills")
+
+    readme = api.upload_file.call_args.kwargs["path_or_fileobj"].decode()
+    assert 'config_name: "actions-131"' in readme
+    assert 'path: "actions/131/*.parquet"' in readme
+    assert 'config_name: "132"' in readme
+    assert 'config_name: "actions-132"' not in readme, "only published sessions get a config"
+
+
+def test_the_card_is_still_correct_before_actions_is_ever_published(mocker):
+    """A repo with no actions/ directory must still get a valid card, not a
+    traceback and not a template with an unfilled placeholder."""
+    from maine_bills.publish import sync_dataset_card
+
+    api = MagicMock()
+
+    def tree_or_raise(repo_id, repo_type, path_in_repo):
+        if path_in_repo == "actions":
+            raise FileNotFoundError("actions not found")
+        return tree(["data/132"])
+
+    api.list_repo_tree.side_effect = tree_or_raise
+    mocker.patch("maine_bills.publish.HfApi", return_value=api)
+
+    sync_dataset_card("pem207/maine-bills")
+
+    readme = api.upload_file.call_args.kwargs["path_or_fileobj"].decode()
+    front_matter = readme.split("---")[1]
+    assert 'config_name: "132"' in front_matter
+    # Scoped to the front matter: the prose below documents `actions-<session>`
+    # as a naming convention whether or not any are published yet.
+    assert "actions-" not in front_matter
+    assert "{" not in front_matter, "no unfilled template placeholder"
+    # The repo-wide `actions` config stays declared; it globs an empty
+    # directory harmlessly and means publishing later needs no card change.
+    assert 'config_name: "actions"' in front_matter


### PR DESCRIPTION
Queued after #22 merged. Prepares everything so publishing is one approved dispatch away. **Nothing here uploads on its own** — merging this does not publish anything.

## Risk summary

**What is irreversible or outward-facing:** this adds the only code path in the repo that writes the `actions` config to HuggingFace, and it defines where that config lives in the published repo. Once a consumer joins against `actions/<session>/`, the path and the config names are a compatibility surface. A bad upload is a visible bad revision on a public dataset, not a red check.

**What was verified:** the default `all` config's glob cannot reach the actions path (asserted on the template itself, not just by inspection); the workflow job declares `environment: huggingface-publish` and `build-actions` never sees `HF_TOKEN` (asserted by parsing the YAML); the script re-validates every parquet before uploading any of it. 600 tests passing, ruff clean on `src/`, `tests/`, `scripts/`.

**What was not verified:** nothing has been uploaded. The publish path has never run against the real Hub, by design — that is what the gate is for.

## The load-bearing decision: `actions/`, not `data/`

The default `all` config globs `data/**/*.parquet`. An actions parquet placed **anywhere** beneath `data/` would therefore load as bill rows — a second, incompatible schema silently unioned into the config that every consumer gets when they don't name one.

So the config lives at `actions/<session>/train-00000-of-00001.parquet`, a sibling of `data/`, which makes the two globs disjoint by construction rather than by convention.

`test_the_default_config_glob_cannot_reach_the_actions_path` asserts this against the card template itself, so a later change that moves actions under `data/` fails in CI rather than in someone's `load_dataset` call.

## The gate

`publish-actions` is the **only** job in `data-run.yml` that declares `environment:`. That declaration *is* the gate: the environment carries a required reviewer, and `HF_TOKEN` exists nowhere else in the repo. A dispatch cannot reach the Hub without you approving that specific run.

**Split from `build-actions` on purpose.** Building is cheap, ungated and repeatable; publishing is neither. One combined job would queue every rebuild for human approval, which trains people to click through the approval — the failure mode a gate is most vulnerable to.

**`dry_run` defaults to `true`**, so the accident-shaped dispatch — pick the task, paste a run id, hit go — validates and reports what it *would* upload, then stops.

## Re-validation before upload

`scripts/publish_actions_config.py` does not trust the artifact. Build and publish run as different jobs on different runners, and an artifact can arrive truncated. Per session it checks: exact published column layout, non-empty, unique `ld_number` (a repeated join key multiplies rows in the bills table), and that the file holds only the session its directory claims.

It validates **the whole set before uploading any of it**, so a bad session eleven files in does not leave the Hub holding ten uploaded ones and a failure.

Refusals that are easy to get wrong and are covered:
- an empty input directory is an error, not a success — "nothing to upload" and "uploaded nothing" are the same line in a log;
- a session directory whose parquet is missing, which is exactly what a half-finished build leaves behind;
- `build-summary.json` is not uploaded — it describes the build, not the data, and would land in the repo root.

## Dataset card

`sync_dataset_card()` now emits `actions-<session>` configs alongside the bills ones, plus a repo-wide `actions` config.

A repo that has **never** published an actions config still gets a correct card: the tree lookup returns `[]` for a missing directory rather than raising, because that is a normal state rather than an error. Covered by `test_the_card_is_still_correct_before_actions_is_ever_published`, which also asserts no unfilled template placeholder survives into the front matter.

The card gains a `## Configs` table distinguishing the two row grains (one per **document** vs. one per **bill**), the full `actions` schema, and the join semantics — including that the join is one-to-many from the actions side, because amendments share their parent's `ld_number`.

## Unrelated correction

The card claimed **four** sponsor-enrichment columns while listing five. v2 added `sponsor_chambers` too. One word, user-facing, and I was already editing the file.

## How to actually publish, once this merges

1. Dispatch `build-actions` with the three backfill run ids → produces the `actions-config` artifact.
2. Dispatch `publish-actions` with that build's run id, `dry_run: true` → validates, reports, uploads nothing.
3. Same dispatch with `dry_run: false` → approve the environment, and it uploads plus re-syncs the card.

I have not run any of these.

## Tests

Seven new. The ones worth reading are `test_the_default_config_glob_cannot_reach_the_actions_path` and `test_the_card_is_still_correct_before_actions_is_ever_published`.

## Rollback

Revert the commit. Nothing has been uploaded, so there is no Hub state to undo. If a publish has already run by the time this is reverted, the uploaded files remain and would need deleting from the dataset repo directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WicqsC1r64bRg1pbAqFsTV)_