### PR TITLE
[Tier-2] a denylist-colliding surname was dropped outside rosters

### DIFF
--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -209,27 +209,41 @@ _ROSTER_MAX_NAME_WORDS = 4
 _ROSTER_CELL_SPLIT = re.compile(r",(?!\s*[A-Z]\.\s+of\s)")
 
 
-# Words on the general title_words denylist that ARE real Maine surnames, and
-# so must not be filtered on the roster path.
+# Words on the title_words denylist that ARE real Maine surnames, and so must
+# not reject a name that IS exactly that word. Rep. Hall of Wilton sat in
+# session 129, and session 121's published data carries 80 HALL mentions.
 #
-# The denylist exists for the title-adjoining patterns, where "Hall" appears as
-# "City Hall". Inside a roster the same token is positionally a surname -- Rep.
-# Hall of Wilton sat in session 129 -- and the roster is already anchored to a
-# chamber label, so the false-positive risk that justifies the denylist
-# elsewhere is not present here.
+# Applied on EVERY path, not only inside rosters, and the history of that is
+# the point of the comment. When the denylist was case-folded (correctly -- it
+# had been structurally inert on the all-caps roster path), the collision with
+# Hall surfaced, and the rescue was scoped to the roster path on the reasoning
+# that the denylist "exists for the title-adjoining patterns". That reasoning
+# quietly assumed Hall could only appear in a roster. It cannot:
 #
-# This became reachable only when the denylist was case-folded: before that it
-# matched nothing at all on this all-caps path, so activating it correctly also
-# activated this collision.
-_ROSTER_NAME_ALLOW = {"hall"}
+#     Presented by Representative HALL of Wilton.    ->  []
+#
+# extracted NOTHING -- the bill's primary sponsor, on the oldest and most
+# reliable pattern in the file, dropped by a guard doing its job one path over.
+# Same defect class as the roster-only fixes before it: a rescue scoped to
+# where the symptom was seen rather than to where the rule applies.
+#
+# The allow is an exact whole-name match, so it cannot weaken the word-level
+# check that motivates the denylist: "City Hall" still fails on "city", and
+# any phrase containing a denylisted word alongside others still fails.
+# A trailing disambiguator is stripped first -- "HALL, A." is still Hall.
+_NAME_ALLOW = {"hall"}
+
+_NAME_DISAMBIGUATOR = re.compile(r",\s*[A-Z]\.$")
+
+
+def _allowed_name(name: str) -> bool:
+    return _NAME_DISAMBIGUATOR.sub("", name).casefold() in _NAME_ALLOW
 
 
 def _roster_name_ok(name: str, is_valid_name) -> bool:
     """Whether a roster cell's name should be kept."""
     if not _ROSTER_SURNAME.search(name):
         return False
-    if name.casefold() in _ROSTER_NAME_ALLOW:
-        return True
     return is_valid_name(name, max_words=_ROSTER_MAX_NAME_WORDS)
 
 
@@ -656,6 +670,12 @@ class TextExtractor:
             # legislator who shares a surname but sits in the other chamber.
             if not name or len(name.split()) > max_words:
                 return False
+            # A name that IS a real surname colliding with the denylist. Checked
+            # here rather than on any single calling path, because scoping it to
+            # where the collision was first seen is how "Presented by
+            # Representative HALL of Wilton" came to extract nothing.
+            if _allowed_name(name):
+                return True
             # Compared case-INSENSITIVELY. title_words is written in Title Case
             # and rosters print surnames in capitals, so a case-sensitive
             # intersection made this filter structurally inert on the roster

--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -211,7 +211,9 @@ _ROSTER_CELL_SPLIT = re.compile(r",(?!\s*[A-Z]\.\s+of\s)")
 
 # Words on the title_words denylist that ARE real Maine surnames, and so must
 # not reject a name that IS exactly that word. Rep. Hall of Wilton sat in
-# session 129, and session 121's published data carries 80 HALL mentions.
+# session 129, and this fix recovers HALL on 79 session-121 bills (76 via the
+# title-adjoining patterns, 3 via rosters -- measured, and independently
+# reproduced by review).
 #
 # Applied on EVERY path, not only inside rosters, and the history of that is
 # the point of the comment. When the denylist was case-folded (correctly -- it

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -995,3 +995,55 @@ def test_a_name_carries_at_most_one_particle_and_one_initial():
     # ...and it must survive the whole pipeline, not just the pattern.
     text = "Cosponsored by Senators: CORNELL du HOUX, J. of Brunswick.\n"
     assert names(text) == ["CORNELL du HOUX, J."]
+
+
+# --- the HALL regression: a rescue scoped to where the symptom was seen ---
+#
+# Found by the issue-#13 re-extraction measurement: HALL was lost in EVERY
+# session, 80 mentions in 121 alone, because the roster-only allowlist assumed
+# a denylist-colliding surname could only appear inside a roster.
+
+
+def test_a_denylist_colliding_surname_survives_the_presented_by_pattern():
+    """The primary sponsor, on the oldest pattern in the file. This extracted
+    [] on main."""
+    text = "Presented by Representative HALL of Wilton.\nBe it enacted:\n"
+    assert names(text) == ["HALL"]
+    assert mentions(text)["HALL"] == "House"
+
+
+def test_a_denylist_colliding_surname_survives_the_cosponsored_by_pattern():
+    text = (
+        "Presented by Senator BAILEY of York.\n"
+        "Cosponsored by Representative HALL of Wilton and Senator CURRY of Waldo.\n"
+        "Be it enacted:\n"
+    )
+    assert names(text) == ["BAILEY", "HALL", "CURRY"]
+
+
+def test_the_allow_still_holds_inside_a_roster():
+    """The path the rescue was originally scoped to must not regress."""
+    text = "Cosponsored by Representatives: HALL of Wilton, CURRY of Waldo.\nBe it enacted:\n"
+    assert names(text) == ["HALL", "CURRY"]
+
+
+def test_the_allow_composes_with_a_disambiguating_initial():
+    """Two sitting Halls in one chamber. "HALL, A." is still Hall — the
+    trailing initial is part of the name string, not of the surname identity.
+    Found immaterial-but-real by the #24 re-review; free once the allow moved
+    to is_valid_name."""
+    text = "Cosponsored by Senators: HALL, A. of Wilton, CURRY of Waldo.\nBe it enacted:\n"
+    assert names(text) == ["HALL, A.", "CURRY"]
+
+
+def test_the_allow_is_an_exact_match_not_a_word_match():
+    """It must not weaken the word-level check that motivates the denylist:
+    a phrase CONTAINING hall is not the surname Hall."""
+    for cell in ("CITY HALL of Portland", "HALL COUNTY of Somewhere"):
+        text = f"Cosponsored by Senators: BAILEY of York, {cell}.\nBe it enacted:\n"
+        assert names(text) == ["BAILEY"], cell
+    # And prose around the title-adjoining patterns stays out: "City Hall"
+    # cannot reach them at all (they require a title prefix), but the denylist
+    # words themselves must still be rejected as bare names.
+    text = "Cosponsored by Senators: BAILEY of York, COUNTY of Cumberland.\nBe it enacted:\n"
+    assert names(text) == ["BAILEY"]

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -1039,7 +1039,11 @@ def test_the_allow_composes_with_a_disambiguating_initial():
 def test_the_allow_is_an_exact_match_not_a_word_match():
     """It must not weaken the word-level check that motivates the denylist:
     a phrase CONTAINING hall is not the surname Hall."""
-    for cell in ("CITY HALL of Portland", "HALL COUNTY of Somewhere"):
+    # "CHAMBER of Commerce" pins the allowlist's CONTENTS, not just its
+    # mechanism: review found that adding "chamber" to _NAME_ALLOW survived
+    # every test, and Chamber is the one other denylist word the code comment
+    # flags as surname-plausible. Accidental allowlist growth should fail here.
+    for cell in ("CITY HALL of Portland", "HALL COUNTY of Somewhere", "CHAMBER of Commerce"):
         text = f"Cosponsored by Senators: BAILEY of York, {cell}.\nBe it enacted:\n"
         assert names(text) == ["BAILEY"], cell
     # And prose around the title-adjoining patterns stays out: "City Hall"


### PR DESCRIPTION
Found by the issue-#13 re-extraction measurement, which showed `HALL` lost in **every** session — 80 mentions in session 121 alone — and traced to:

```
Presented by Representative HALL of Wilton.   →   []
```

The primary sponsor, on the oldest and most reliable pattern in the file, extracted as nothing. This is live in `main` and affects every future scrape.

## Cause: a rescue scoped to where the symptom was seen

When #16 case-folded the `title_words` denylist (correctly — it had been structurally inert on the all-caps roster path), the collision with the real legislator Hall surfaced *on the roster path*, and the fix was `_ROSTER_NAME_ALLOW`, applied only inside rosters, reasoning that the denylist "exists for the title-adjoining patterns."

That reasoning quietly assumed Hall could only appear in a roster. `Presented by` and `Cosponsored by` lines proved otherwise — and this is the same defect class the #24 re-review found one layer down: two guards in series, a fix applied at the wrong altitude.

## Fix

The allowlist moves into `is_valid_name` itself, so it holds on every path a name reaches it by; the roster-specific rescue is **deleted** rather than kept as a second copy.

- **Exact whole-name match**, so it cannot weaken the word-level check that motivates the denylist: `CITY HALL of Portland` still fails on `city`.
- A trailing disambiguator is stripped first, so `HALL, A.` is still Hall — closing the immaterial-but-real gap the #24 re-review recorded (two sitting Halls in one chamber).

## Measurement, this branch vs `main`, over real published text

| Session | Bills changed | Gained | Lost |
|---|---|---|---|
| 121 | 79 | `HALL` ×79 | — |
| 129 | 1 | `HALL` ×1 | — |
| 132 | 9 | `HALL` ×9 | — |

Nothing but `HALL` moves, in either direction.

## Tier decision

Tier 2 — `text_extractor.py` + tests only, per `docs/GOVERNANCE.md` ("extraction/matching/scraper code, tests"). No schema, publish, `.github/`, or dependency surface.

## Risk

Blast radius is the `sponsors` column of future scrapes and re-extractions. The measurement above is the check: the change is provably `HALL`-only on real data. The one behavior widened is that an exact denylist word now passes *when it is the entire name and on the allowlist* — a list of size one.

## Checks

598 passing; ruff clean. Mutations in place (sanity: sweep disabled → 58 failures): allow check removed → 6 failures, allow made word-level → 2, disambiguator not stripped → 1, allow emptied → 6. All killed.

## Rollback

Revert the commit. No state; published parquet untouched until a re-extraction runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WicqsC1r64bRg1pbAqFsTV)_