### PR TITLE
[Tier-2] strip page furniture that a page break drops mid-roster

### DIFF
--- a/src/maine_bills/text_extractor.py
+++ b/src/maine_bills/text_extractor.py
@@ -22,6 +22,27 @@ _CHAMBER_BY_TITLE = {
 # has 99 cosponsors and its block alone exceeds 3,000 characters.
 _SPONSOR_WINDOW = 8000
 
+# Page furniture that the PDF text layer interleaves MID-ROSTER when a long
+# cosponsor list crosses a page break. It lands between two cells:
+#
+#     ... BURSTEIN of Lincolnville,
+#     Printed on recycled paper
+#     CAMPBELL of Newfield, ...
+#
+# and after whitespace normalization the next cell reads "Printed on recycled
+# paper CAMPBELL of Newfield" -- not a well-formed entry, so the roster run
+# terminates there and every cosponsor behind it is lost. Session 127 LD 1673
+# loses 53 of its 79 sponsors to this one line; the phrase sits inside the
+# cosponsor block of 22 bills across sessions 125-128 (clean digital PDFs --
+# this is not OCR damage, see issue #31 for that).
+#
+# Removed BEFORE the block is parsed rather than tolerated by the grammar,
+# because the contiguity rule is load-bearing: teaching the sweep to skip
+# malformed cells is the old prose-harvesting sweep with extra steps. An exact
+# literal, not a pattern -- the phrase is fixed, and page furniture is the one
+# vocabulary where an over-eager pattern could eat bill text.
+_PAGE_FURNITURE = re.compile(r"\bPrinted on recycled paper\b")
+
 # Where the sponsor block ends. Worth being explicit now that the window is wide
 # -- without these the block would run to the window edge and the title-adjoining
 # patterns could pick up "Senator X of Y" out of the bill's body text.
@@ -566,6 +587,9 @@ class TextExtractor:
         normalized_text = " ".join(search_text.split())
         # Normalize stray spaces around hyphens in names (e.g., "BEEBE- CENTER" -> "BEEBE-CENTER")
         normalized_text = re.sub(r"([A-Z])\s*-\s*([A-Z])", r"\1-\2", normalized_text)
+        # Strip page furniture that a page break drops mid-roster; one such line
+        # otherwise terminates the run and costs every cosponsor behind it.
+        normalized_text = _PAGE_FURNITURE.sub(" ", normalized_text)
 
         # Title filter - exclude these common false positives
         title_words = {

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -1051,3 +1051,57 @@ def test_the_allow_is_an_exact_match_not_a_word_match():
     # words themselves must still be rejected as bare names.
     text = "Cosponsored by Senators: BAILEY of York, COUNTY of Cumberland.\nBe it enacted:\n"
     assert names(text) == ["BAILEY"]
+
+
+# --- page furniture interleaved mid-roster ---
+#
+# Found sizing the issue-#13 re-extraction: session 127's entire 53-name loss
+# was ONE bill (LD 1673) where a page break dropped "Printed on recycled paper"
+# between two roster cells. 22 bills across sessions 125-128 carry the phrase
+# inside their cosponsor block. Not OCR damage -- these are clean digital PDFs.
+
+
+def test_a_page_footer_mid_roster_does_not_end_the_run():
+    """The real shape from 127 LD 1673: the footer lands between two cells, so
+    the next cell reads "Printed on recycled paper CAMPBELL of Newfield" and
+    the run died there, losing everything behind it."""
+    text = (
+        "Presented by Senator ALFOND of Cumberland.\n"
+        "Cosponsored by Representatives: BATTLE of South Portland, "
+        "BURSTEIN of Lincolnville, \nPrinted on recycled paper \n"
+        "CAMPBELL of Newfield, CHENETTE of Saco, DUNPHY of Old Town.\n"
+        "Be it enacted by the People of the State of Maine as follows:\n"
+    )
+    assert names(text) == [
+        "ALFOND",
+        "BATTLE",
+        "BURSTEIN",
+        "CAMPBELL",
+        "CHENETTE",
+        "DUNPHY",
+    ]
+
+
+def test_the_footer_before_the_block_is_harmless_too():
+    text = (
+        "Printed on recycled paper\n"
+        "Presented by Senator ALFOND of Cumberland.\n"
+        "Cosponsored by Senators: BAILEY of York, CURRY of Waldo.\nBe it enacted:\n"
+    )
+    assert names(text) == ["ALFOND", "BAILEY", "CURRY"]
+
+
+def test_the_furniture_strip_is_exact_not_a_pattern():
+    """Page furniture is the one vocabulary where an over-eager pattern could
+    eat bill text. A name or locality containing any of those words must
+    survive; only the exact phrase is removed."""
+    text = (
+        "Cosponsored by Senators: PAPER of Augusta, PRINTED of Bangor, "
+        "CURRY of Waldo.\nBe it enacted:\n"
+    )
+    # PAPER and PRINTED are fabricated surnames -- the point is that single
+    # words from the phrase are not stripped, so these cells stay intact and
+    # rise or fall on the ordinary guards, not on the furniture rule.
+    result = names(text)
+    assert "CURRY" in result
+    assert result == ["PAPER", "PRINTED", "CURRY"]

--- a/tests/unit/test_sponsor_roster_lists.py
+++ b/tests/unit/test_sponsor_roster_lists.py
@@ -1094,7 +1094,14 @@ def test_the_footer_before_the_block_is_harmless_too():
 def test_the_furniture_strip_is_exact_not_a_pattern():
     """Page furniture is the one vocabulary where an over-eager pattern could
     eat bill text. A name or locality containing any of those words must
-    survive; only the exact phrase is removed."""
+    survive; only the exact phrase is removed.
+
+    Honest note on strength, from review: the all-caps fixtures below only
+    catch a CASE-INSENSITIVE widening on their own -- a case-sensitive
+    single-word widening slips past them and is killed instead by the
+    mid-roster test's leftover " on ". The mixed-case cell pins the
+    case-sensitive direction directly.
+    """
     text = (
         "Cosponsored by Senators: PAPER of Augusta, PRINTED of Bangor, "
         "CURRY of Waldo.\nBe it enacted:\n"
@@ -1105,3 +1112,22 @@ def test_the_furniture_strip_is_exact_not_a_pattern():
     result = names(text)
     assert "CURRY" in result
     assert result == ["PAPER", "PRINTED", "CURRY"]
+
+
+def test_the_furniture_list_is_exactly_one_phrase():
+    """Pins the SCOPE of _PAGE_FURNITURE, not just its mechanism. Review grew
+    the pattern with "STATE OF MAINE" and every test stayed green -- the exact
+    over-eager growth the pattern's own comment warns against, unpinned. A
+    roster whose locality contains that header text must survive, and the
+    pattern must match nothing but the one footer."""
+    import re as _re
+
+    from maine_bills.text_extractor import _PAGE_FURNITURE
+
+    # The pattern is the one literal, case-sensitive.
+    assert _PAGE_FURNITURE.pattern == r"\bPrinted on recycled paper\b"
+    assert not _PAGE_FURNITURE.flags & _re.IGNORECASE
+
+    # And behaviourally: common page-header vocabulary is NOT furniture here.
+    for phrase in ("STATE OF MAINE", "Page 3", "printed on recycled paper"):
+        assert _PAGE_FURNITURE.search(phrase) is None, phrase


### PR DESCRIPTION
Found sizing the issue-#13 re-extraction: session 127's entire 53-name loss was **one bill**, LD 1673, where the PDF text layer interleaved `Printed on recycled paper` between two roster cells:

```
... BURSTEIN of Lincolnville,
Printed on recycled paper
CAMPBELL of Newfield, ...
```

The next cell was not a well-formed entry, the run terminated, and everything behind it was lost. The phrase sits inside the cosponsor block of 22 bills across sessions 125–128. These are clean digital PDFs — this is **not** the OCR damage tracked in #31.

## Design

Removed **before** the block is parsed, rather than tolerated by the grammar. The contiguity rule is load-bearing — teaching the sweep to skip malformed cells is the old prose-harvesting sweep with extra steps. An exact literal, not a pattern: page furniture is the one vocabulary where an over-eager pattern could eat bill text, and the mutation widening it to single words is caught by a test with fabricated `PAPER`/`PRINTED` surnames.

## Measurement, this branch vs `main`, bills carrying the phrase in their sponsor window

| Session | Bills changed | Mentions | Lost |
|---|---|---|---|
| 125 | 0 | — | — |
| 126 | 2 | +19 | 0 |
| 127 | 1 | +58 | 0 |
| 128 | 1 | +8 | 0 |

Session 125's six footer bills change nothing — the footer sits outside the roster run there, and a no-op where the phrase is harmless is the intended behavior. All 84 distinct gained names are real legislators (`SOCTOMAH`, `MONAGHAN-DERRIG`, `TIPPING-SPITZ`, …). Nothing lost anywhere.

## Tier decision

Tier 2 — `text_extractor.py` + tests only. No schema, publish, `.github/`, or dependency surface.

## Risk

Blast radius is the `sponsors` column of future scrapes/re-extractions. The only text ever removed is the exact literal phrase, inside the 8,000-char sponsor window, for name-matching purposes only — the published `text` column itself is untouched by extraction.

## Checks

601 passing, ruff clean. Mutations in place: strip removed → 1 failure; strip widened to single words → 1 failure.

## Rollback

Revert the commit. No state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WicqsC1r64bRg1pbAqFsTV)_