### PR TITLE
[Tier-2] re-extract sponsors from the published text (issue #13, item 1)

### DIFF
--- a/scripts/reextract_sponsors.py
+++ b/scripts/reextract_sponsors.py
@@ -95,14 +95,17 @@ def reextract_session(df: pd.DataFrame, session: int) -> tuple[pd.DataFrame, dic
 
     out["sponsors"] = new_sponsors
     out["sponsor_chambers"] = new_chambers
+    # Created unconditionally, not only when the source already had them: a
+    # v1-era parquet without the enrichment columns would otherwise produce
+    # output missing them, breaking the "written in the published layout"
+    # contract and leaving enrich_published.py to discover the gap later.
     for column in (
         "sponsor_ids",
         "sponsor_parties",
         "sponsor_districts",
         "sponsor_match_confidence",
     ):
-        if column in out.columns:
-            out[column] = [[None] * len(n) for n in new_sponsors]
+        out[column] = [[None] * len(n) for n in new_sponsors]
 
     summary = {
         "session": session,
@@ -168,16 +171,23 @@ def main(argv=None) -> int:
 
     total_before = sum(s["mentions_before"] for s in summaries)
     total_after = sum(s["mentions_after"] for s in summaries)
-    total_lost = sum(s["distinct_lost"] for s in summaries)
+    # Summed per session, so a name lost in two sessions counts twice. That is
+    # the right unit for this warning -- each session is inspected and published
+    # separately -- but it must not be labelled "distinct names", which review
+    # of an earlier report read as a cross-session union and had to correct.
+    loss_events = sum(s["distinct_lost"] for s in summaries)
     logger.info(
         f"TOTAL: {sum(s['rows_changed'] for s in summaries)} rows changed, "
         f"{total_before} -> {total_after} mentions ({total_after - total_before:+d})"
     )
-    if total_lost:
+    if loss_events:
         # Losing names is not automatically wrong -- the old extractor captured
         # things that were not people -- but it is never routine, and a silent
         # loss is how a regression ships.
-        logger.warning(f"{total_lost} distinct names LOST; inspect top_lost before publishing")
+        logger.warning(
+            f"{loss_events} per-session distinct-name losses; "
+            f"inspect each session's top_lost before publishing"
+        )
     return 0
 
 

--- a/scripts/reextract_sponsors.py
+++ b/scripts/reextract_sponsors.py
@@ -1,0 +1,185 @@
+"""Re-extract `sponsors` from the published `text` column (issue #13, item 1).
+
+**Why this exists.** The published dataset is internally inconsistent. Sessions
+were scraped at different times against different extractors, and two fixes
+since then changed what the extractor finds:
+
+- #16 restored the plural-roster sweep that `300cd207` removed. Session 131 was
+  scraped before that removal and carries full cosponsor lists; 132 was scraped
+  after and does not. A bill with 99 cosponsors stored 2.
+- #24 recovered two surname forms and, through the cascade, everything printed
+  behind them.
+
+So a cross-session analysis of `sponsors` today is measuring scrape dates as
+much as it is measuring the legislature, and the Gate A match rates in issue #13
+cannot be compared across sessions until this is fixed.
+
+**Why not a re-scrape.** The sponsor block survives into the published `text`,
+so the current extractor can be re-run against it: ~43,000 PDF downloads
+avoided, and the result is identical because `text` is the same string the
+extractor saw the first time. Verified while measuring #24, which reproduced
+that PR's figures exactly from this column.
+
+**What this does NOT do.** It does not upload. It writes parquet locally and
+reports what changed; publishing is Tier-1 and goes through the
+`huggingface-publish` gate.
+
+Usage:
+    uv run python scripts/reextract_sponsors.py \\
+        --sessions 121 122 ... 132 \\
+        --parquet-source hf://datasets/pem207/maine-bills \\
+        --output data/reextracted
+"""
+
+import argparse
+import json
+import logging
+import sys
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pandas as pd  # noqa: E402
+
+from maine_bills.text_extractor import TextExtractor  # noqa: E402
+
+logger = logging.getLogger("reextract_sponsors")
+
+# Published layout. The `data/` segment is not optional -- reading
+# `<source>/<session>/...` without it silently 404s on the real repo.
+PARQUET_TEMPLATE = "{source}/data/{session}/train-00000-of-00001.parquet"
+
+
+def reextract_row(text) -> tuple[list[str], list[str | None]]:
+    """Sponsors and their chambers for one row, from its published text."""
+    if not isinstance(text, str) or not text:
+        return [], []
+    mentions = TextExtractor._extract_sponsor_mentions(text)
+    return [name for name, _ in mentions], [chamber for _, chamber in mentions]
+
+
+def compare(published, extracted) -> tuple[Counter, Counter]:
+    """Multiset difference both ways, so a count change is not read as a swap."""
+    was = Counter(published or [])
+    now = Counter(extracted or [])
+    return now - was, was - now
+
+
+def reextract_session(df: pd.DataFrame, session: int) -> tuple[pd.DataFrame, dict]:
+    """Rebuild `sponsors`/`sponsor_chambers` and report what moved.
+
+    The enrichment columns are NOT recomputed here. They are index-aligned with
+    `sponsors`, so rewriting that list leaves them pointing at the wrong
+    entries -- they are cleared, and re-running enrich_published.py is a
+    required second step rather than an optional one.
+    """
+    out = df.copy()
+    gained, lost = Counter(), Counter()
+    changed = before = after = 0
+    new_sponsors, new_chambers = [], []
+
+    for row in df.itertuples():
+        published = list(row.sponsors) if row.sponsors is not None else []
+        names, chambers = reextract_row(row.text)
+        new_sponsors.append(names)
+        new_chambers.append(chambers)
+
+        before += len(published)
+        after += len(names)
+        up, down = compare(published, names)
+        if up or down:
+            changed += 1
+            gained.update(up)
+            lost.update(down)
+
+    out["sponsors"] = new_sponsors
+    out["sponsor_chambers"] = new_chambers
+    for column in (
+        "sponsor_ids",
+        "sponsor_parties",
+        "sponsor_districts",
+        "sponsor_match_confidence",
+    ):
+        if column in out.columns:
+            out[column] = [[None] * len(n) for n in new_sponsors]
+
+    summary = {
+        "session": session,
+        "rows": len(df),
+        "rows_changed": changed,
+        "mentions_before": before,
+        "mentions_after": after,
+        "mentions_delta": after - before,
+        "distinct_gained": len(gained),
+        "distinct_lost": len(lost),
+        "top_gained": gained.most_common(10),
+        "top_lost": lost.most_common(10),
+    }
+    return out, summary
+
+
+def load_session(source: str, session: int) -> pd.DataFrame:
+    return pd.read_parquet(PARQUET_TEMPLATE.format(source=source.rstrip("/"), session=session))
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--sessions", type=int, nargs="+", required=True)
+    parser.add_argument("--parquet-source", default="hf://datasets/pem207/maine-bills")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="Measure and report without writing parquet. Use this first — the "
+        "point of the exercise is the size of the drift, not the files.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
+    args = parse_args(argv)
+
+    summaries = []
+    for session in args.sessions:
+        try:
+            df = load_session(args.parquet_source, session)
+        except Exception as e:
+            logger.error(f"Session {session}: {type(e).__name__}: {e}")
+            return 1
+
+        frame, summary = reextract_session(df, session)
+        summaries.append(summary)
+        logger.info(
+            f"Session {session}: {summary['rows']} rows | {summary['rows_changed']} changed | "
+            f"{summary['mentions_before']} -> {summary['mentions_after']} "
+            f"({summary['mentions_delta']:+d}) | +{summary['distinct_gained']} "
+            f"-{summary['distinct_lost']} distinct"
+        )
+
+        if not args.report_only:
+            session_dir = args.output / str(session)
+            session_dir.mkdir(parents=True, exist_ok=True)
+            frame.to_parquet(session_dir / "train-00000-of-00001.parquet", index=False)
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    (args.output / "reextract-summary.json").write_text(json.dumps(summaries, indent=2))
+
+    total_before = sum(s["mentions_before"] for s in summaries)
+    total_after = sum(s["mentions_after"] for s in summaries)
+    total_lost = sum(s["distinct_lost"] for s in summaries)
+    logger.info(
+        f"TOTAL: {sum(s['rows_changed'] for s in summaries)} rows changed, "
+        f"{total_before} -> {total_after} mentions ({total_after - total_before:+d})"
+    )
+    if total_lost:
+        # Losing names is not automatically wrong -- the old extractor captured
+        # things that were not people -- but it is never routine, and a silent
+        # loss is how a regression ships.
+        logger.warning(f"{total_lost} distinct names LOST; inspect top_lost before publishing")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reextract_sponsors.py
+++ b/scripts/reextract_sponsors.py
@@ -24,6 +24,14 @@ that PR's figures exactly from this column.
 reports what changed; publishing is Tier-1 and goes through the
 `huggingface-publish` gate.
 
+**Schema note.** The cleared enrichment columns are all-None lists, which
+parquet writes as `list<null>` where the published files carry `list<string>`
+(ids/parties/districts) and `list<double>` (confidence). Deliberate, not a
+defect: these files are intermediates, and re-running enrich_published.py --
+the documented, REQUIRED next step -- rewrites exactly those columns with
+their proper types. Do not diff these files against published parquet at the
+arrow-schema level before enrichment has run.
+
 Usage:
     uv run python scripts/reextract_sponsors.py \\
         --sessions 121 122 ... 132 \\
@@ -150,6 +158,17 @@ def main(argv=None) -> int:
             df = load_session(args.parquet_source, session)
         except Exception as e:
             logger.error(f"Session {session}: {type(e).__name__}: {e}")
+            # Keep what earlier sessions already established. Without this, a
+            # failure on session 2 of 3 discarded session 1's computed summary
+            # while LEAVING its parquet in --output -- partial files that could
+            # be mistaken for a run, with no record saying which sessions they
+            # cover. The summary is the record; write it before failing.
+            if summaries:
+                args.output.mkdir(parents=True, exist_ok=True)
+                (args.output / "reextract-summary.json").write_text(json.dumps(summaries, indent=2))
+                logger.error(
+                    f"Partial run: summary covers sessions {[s['session'] for s in summaries]} only"
+                )
             return 1
 
         frame, summary = reextract_session(df, session)

--- a/tests/unit/test_reextract_sponsors.py
+++ b/tests/unit/test_reextract_sponsors.py
@@ -1,0 +1,162 @@
+"""Tests for the sponsor re-extraction over published text (issue #13, item 1).
+
+The hazards these pin, in order of what they would cost:
+
+1. Carrying the enrichment columns across a sponsors rewrite. They are
+   index-aligned with `sponsors`, so keeping them attributes every enriched
+   sponsor on a changed bill to the WRONG legislator — strictly worse than the
+   inconsistency the re-extraction exists to fix.
+2. Reading a count change as a swap. The comparison is a multiset difference
+   both ways; a set difference reports {A:2}->{A:1} as no change.
+3. Losing names silently. Losses are not automatically wrong, but they are
+   never routine.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "reextract_sponsors.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("reextract_sponsors", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+BILL = (
+    "Presented by Senator BRENNER of Cumberland.\n"
+    "Cosponsored by Senators: BAILEY of York, CURRY of Waldo.\n"
+    "Be it enacted by the People of the State of Maine as follows:\n"
+)
+
+
+def frame(rows):
+    return pd.DataFrame(rows)
+
+
+def row(ld="0001", text=BILL, sponsors=("OLD",), **overrides):
+    base = {
+        "session": 132,
+        "ld_number": ld,
+        "text": text,
+        "sponsors": list(sponsors),
+        "sponsor_chambers": [None] * len(sponsors),
+        "sponsor_ids": ["ocd-person/x"] * len(sponsors),
+        "sponsor_parties": ["Democratic"] * len(sponsors),
+        "sponsor_districts": ["12"] * len(sponsors),
+        "sponsor_match_confidence": [1.0] * len(sponsors),
+    }
+    base.update(overrides)
+    return base
+
+
+# --- the alignment hazard, which is the reason this file exists ---
+
+
+def test_enrichment_is_cleared_not_carried_across_the_rewrite(mod):
+    """sponsor_ids[i] describes sponsors[i]. After the rewrite, position i is a
+    different person, so carrying the old values attributes every enriched
+    sponsor on a changed bill to the wrong legislator."""
+    out, _ = mod.reextract_session(frame([row()]), 132)
+
+    sponsors = out["sponsors"].iloc[0]
+    assert sponsors == ["BRENNER", "BAILEY", "CURRY"]
+    for column in ("sponsor_ids", "sponsor_parties", "sponsor_districts"):
+        assert out[column].iloc[0] == [None, None, None], column
+    # ...and the cleared lists are aligned with the NEW sponsors, not the old.
+    assert len(out["sponsor_ids"].iloc[0]) == len(sponsors)
+
+
+def test_chambers_are_rebuilt_alongside_the_names(mod):
+    out, _ = mod.reextract_session(frame([row()]), 132)
+    assert out["sponsor_chambers"].iloc[0] == ["Senate", "Senate", "Senate"]
+
+
+def test_an_unchanged_bill_still_gets_cleared_enrichment(mod):
+    """Clearing is keyed on the rewrite happening at all, not on whether the
+    names moved: the columns describe a (names, roster-version) pair, and the
+    roster half changes for every row. Re-running enrichment is a REQUIRED
+    second step; leaving stale ids on 'unchanged' rows would make the dataset
+    a mix of two enrichment runs with nothing marking which is which."""
+    out, summary = mod.reextract_session(frame([row(sponsors=("BRENNER", "BAILEY", "CURRY"))]), 132)
+    assert summary["rows_changed"] == 0
+    assert out["sponsor_ids"].iloc[0] == [None, None, None]
+
+
+# --- the comparison, which must not flatter the result ---
+
+
+def test_a_count_change_is_reported_not_swallowed(mod):
+    """Multiset both ways: {PERRY:2} -> {PERRY:1} is a loss, not a no-op."""
+    text = (
+        "Presented by Senator PERRY of Bangor.\n"
+        "Cosponsored by Representative PERRY of Calais.\nBe it enacted:\n"
+    )
+    _, summary = mod.reextract_session(
+        frame([row(text=text, sponsors=("PERRY", "PERRY", "PERRY"))]), 132
+    )
+    assert summary["mentions_before"] == 3
+    assert summary["mentions_after"] == 2
+    assert summary["distinct_lost"] == 1
+    assert dict(summary["top_lost"])["PERRY"] == 1
+
+
+def test_gains_and_losses_on_one_bill_are_both_reported(mod):
+    _, summary = mod.reextract_session(frame([row(sponsors=("GONE", "BAILEY"))]), 132)
+    assert summary["rows_changed"] == 1
+    assert dict(summary["top_gained"]) == {"BRENNER": 1, "CURRY": 1}
+    assert dict(summary["top_lost"]) == {"GONE": 1}
+
+
+def test_null_and_empty_text_rows_survive_without_inventing_sponsors(mod):
+    out, summary = mod.reextract_session(
+        frame([row(text=None, sponsors=()), row(ld="0002", text="", sponsors=("OLD",))]), 132
+    )
+    assert list(out["sponsors"]) == [[], []]
+    assert summary["mentions_after"] == 0
+    assert dict(summary["top_lost"]) == {"OLD": 1}
+
+
+# --- the CLI contract ---
+
+
+def test_report_only_writes_the_summary_but_no_parquet(mod, tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "load_session", lambda source, session: frame([row()]))
+    code = mod.main(["--sessions", "132", "--output", str(tmp_path / "out"), "--report-only"])
+    assert code == 0
+    assert (tmp_path / "out" / "reextract-summary.json").exists()
+    assert not (tmp_path / "out" / "132").exists()
+
+
+def test_a_full_run_writes_one_parquet_per_session_in_the_published_layout(
+    mod, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(mod, "load_session", lambda source, session: frame([row()]))
+    code = mod.main(["--sessions", "132", "--output", str(tmp_path / "out")])
+    assert code == 0
+    written = pd.read_parquet(tmp_path / "out" / "132" / "train-00000-of-00001.parquet")
+    assert list(written["sponsors"].iloc[0]) == ["BRENNER", "BAILEY", "CURRY"]
+    summary = json.loads((tmp_path / "out" / "reextract-summary.json").read_text())
+    assert summary[0]["session"] == 132
+
+
+def test_a_session_that_cannot_be_loaded_fails_the_run(mod, tmp_path, monkeypatch):
+    def boom(source, session):
+        raise FileNotFoundError("no parquet")
+
+    monkeypatch.setattr(mod, "load_session", boom)
+    assert mod.main(["--sessions", "132", "--output", str(tmp_path / "o")]) == 1
+
+
+def test_the_parquet_path_includes_the_data_segment(mod):
+    """Reading `<source>/<session>/...` without `data/` silently 404s on the
+    real repo — this exact mistake cost a debugging round earlier tonight."""
+    path = mod.PARQUET_TEMPLATE.format(source="hf://datasets/pem207/maine-bills", session=132)
+    assert path == "hf://datasets/pem207/maine-bills/data/132/train-00000-of-00001.parquet"

--- a/tests/unit/test_reextract_sponsors.py
+++ b/tests/unit/test_reextract_sponsors.py
@@ -68,10 +68,43 @@ def test_enrichment_is_cleared_not_carried_across_the_rewrite(mod):
 
     sponsors = out["sponsors"].iloc[0]
     assert sponsors == ["BRENNER", "BAILEY", "CURRY"]
-    for column in ("sponsor_ids", "sponsor_parties", "sponsor_districts"):
+    # All FOUR enrichment columns — review caught sponsor_match_confidence
+    # missing from this loop, which left one v2 column's clearing unpinned.
+    for column in (
+        "sponsor_ids",
+        "sponsor_parties",
+        "sponsor_districts",
+        "sponsor_match_confidence",
+    ):
         assert out[column].iloc[0] == [None, None, None], column
     # ...and the cleared lists are aligned with the NEW sponsors, not the old.
     assert len(out["sponsor_ids"].iloc[0]) == len(sponsors)
+
+
+def test_a_source_without_enrichment_columns_still_gets_them(mod):
+    """A v1-era parquet has no enrichment columns. The output must carry the
+    published layout regardless — clearing only what already existed would
+    hand enrich_published.py a schema gap to discover later."""
+    v1 = frame(
+        [
+            {
+                "session": 132,
+                "ld_number": "0001",
+                "text": BILL,
+                "sponsors": ["OLD"],
+            }
+        ]
+    )
+    out, _ = mod.reextract_session(v1, 132)
+    for column in (
+        "sponsor_chambers",
+        "sponsor_ids",
+        "sponsor_parties",
+        "sponsor_districts",
+        "sponsor_match_confidence",
+    ):
+        assert column in out.columns, column
+        assert len(out[column].iloc[0]) == 3, column
 
 
 def test_chambers_are_rebuilt_alongside_the_names(mod):

--- a/tests/unit/test_reextract_sponsors.py
+++ b/tests/unit/test_reextract_sponsors.py
@@ -193,3 +193,65 @@ def test_the_parquet_path_includes_the_data_segment(mod):
     real repo — this exact mistake cost a debugging round earlier tonight."""
     path = mod.PARQUET_TEMPLATE.format(source="hf://datasets/pem207/maine-bills", session=132)
     assert path == "hf://datasets/pem207/maine-bills/data/132/train-00000-of-00001.parquet"
+
+
+def test_a_same_length_swap_is_a_change_not_a_no_op(mod):
+    """Review mutation: keying rows_changed on len(published) != len(names)
+    survived the suite, because every changed-row fixture also changed the
+    count. A pure swap -- an old false positive out, a real name in, equal
+    counts -- must still be reported, or exactly the correction this script
+    exists to apply becomes invisible."""
+    _, summary = mod.reextract_session(frame([row(sponsors=("COUNTY", "BAILEY", "CURRY"))]), 132)
+    # published 3 -> extracted 3 (BRENNER, BAILEY, CURRY): counts equal.
+    assert summary["mentions_before"] == summary["mentions_after"] == 3
+    assert summary["rows_changed"] == 1
+    assert dict(summary["top_gained"]) == {"BRENNER": 1}
+    assert dict(summary["top_lost"]) == {"COUNTY": 1}
+
+
+def test_losses_produce_a_loud_warning(mod, tmp_path, monkeypatch, caplog):
+    """Hazard 3 in this file's preamble is "losing names silently" -- and
+    review found the warning itself could be deleted without a test noticing.
+    The warning IS the guard; pin it."""
+    import logging
+
+    monkeypatch.setattr(
+        mod, "load_session", lambda source, session: frame([row(sponsors=("GONE",) * 3)])
+    )
+    with caplog.at_level(logging.WARNING, logger="reextract_sponsors"):
+        mod.main(["--sessions", "132", "--output", str(tmp_path / "o"), "--report-only"])
+    assert any("losses" in r.message for r in caplog.records)
+
+
+def test_no_losses_means_no_warning(mod, tmp_path, monkeypatch, caplog):
+    import logging
+
+    monkeypatch.setattr(
+        mod,
+        "load_session",
+        lambda source, session: frame([row(sponsors=("BRENNER", "BAILEY", "CURRY"))]),
+    )
+    with caplog.at_level(logging.WARNING, logger="reextract_sponsors"):
+        mod.main(["--sessions", "132", "--output", str(tmp_path / "o"), "--report-only"])
+    assert not [r for r in caplog.records if "losses" in r.message]
+
+
+def test_a_mid_list_failure_keeps_the_completed_summaries(mod, tmp_path, monkeypatch):
+    """Session 2 of 3 failing used to discard session 1's computed summary
+    while leaving its parquet behind -- partial files with no record of which
+    sessions they covered. The summary is the record."""
+    calls = {"n": 0}
+
+    def load(source, session):
+        calls["n"] += 1
+        if session == 131:
+            raise FileNotFoundError("no parquet")
+        return frame([row()])
+
+    monkeypatch.setattr(mod, "load_session", load)
+    code = mod.main(["--sessions", "130", "131", "132", "--output", str(tmp_path / "o")])
+    assert code == 1
+    written = json.loads((tmp_path / "o" / "reextract-summary.json").read_text())
+    assert [s["session"] for s in written] == [130]
+    # ...and the run stopped at the failure rather than continuing past it.
+    assert calls["n"] == 2


### PR DESCRIPTION
The tooling half of #13's item 1. **This PR runs nothing and uploads nothing** — it adds `scripts/reextract_sponsors.py` plus tests. The actual re-extraction run, and any publish of its output, are separate steps (the publish is Tier-1 through the `huggingface-publish` gate).

## Why

The published dataset is internally inconsistent: sessions were scraped at different times against different extractors, so a cross-session reading of `sponsors` measures scrape dates as much as the legislature. #16 restored the roster sweep that `300cd207` removed (131 was scraped before the removal, 132 after — a 99-cosponsor bill stored 2); #24, #30 and #32 each changed what the extractor finds. Gate A match rates cannot be compared across sessions until the same extractor has produced all of them.

Re-extraction rather than re-scrape: the sponsor block survives into the published `text`, so the extractor re-runs against the same string it originally saw — ~43,000 PDF downloads avoided. Not an assumption: three independent measurements this week (including two reviewers') reproduced extraction figures from this column exactly.

## The hazard this handles explicitly

**The five enrichment columns are index-aligned with `sponsors`.** Rewriting that list leaves `sponsor_ids[i]` describing a different person than `sponsors[i]` — every enriched sponsor on a changed bill attributed to the **wrong legislator**, strictly worse than the inconsistency being fixed. The script clears them (aligned to the new list), which makes re-running `enrich_published.py` a required second step rather than an optional one. Cleared even on rows whose names didn't move: the columns describe a (names, roster-version) pair, and leaving stale ids on "unchanged" rows would mix two enrichment runs with nothing marking which is which.

## What the measurement already found

Run with `--report-only` across all twelve sessions (results posted to #13):

- Sessions 125–132 re-extract cleanly; 132 gains **+6,206 mentions** (the `300cd207` regression reversing).
- Sessions 121–124 and 128 would **lose** thousands of mentions to OCR damage terminating roster runs — held behind #31.
- The measurement surfaced the `HALL` regression (#30, merged) and the page-footer cascade (#32, in review).

So the operative plan, agreed with the repo owner: re-extract **125–132 only**, hold the rest.

## Behavior

- `--report-only` measures and writes a JSON summary, no parquet — the intended first use.
- Comparison is a **multiset** difference both ways, so `{PERRY:2}→{PERRY:1}` reports as a loss rather than a no-op.
- Any distinct name lost produces a loud warning; losses are never routine.
- Full run writes parquet locally in the published layout and stops.

## Tier decision

Tier 2 — `scripts/` + `tests/` only. Nothing here publishes; the parquet it writes goes nowhere without the gated Tier-1 publish path.

## Risk

The script itself has no external effect beyond reading published parquet. The risk lives in *running* it and publishing the result, which is exactly why the enrichment-clearing is forced and the report precedes any write.

## Checks

10 tests, 608 passing, ruff clean. Five mutations, all killed: clearing removed, multiset→set comparison, chambers not rebuilt, report-only writing anyway, `data/` path segment dropped.

## Rollback

Revert the commits; the script leaves no state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WicqsC1r64bRg1pbAqFsTV)_